### PR TITLE
internal posting should not be dependent if dynamic values are set or not

### DIFF
--- a/Model/Item.php
+++ b/Model/Item.php
@@ -1688,10 +1688,12 @@ class Item_get extends Item {
 
 	public $type = 'get';
 	public $input_attributes = array('type' => 'hidden');
-	private $get_var = 'referred_by';
-	protected $hasChoices = false;
 	public $no_user_input_required = true;
+	public $probably_render = true;
 	public $mysql_field = 'TEXT DEFAULT NULL';
+	protected $hasChoices = false;
+	private $get_var = 'referred_by';
+	
 
 	protected function setMoreOptions() {
 		if (isset($this->type_options_array) AND is_array($this->type_options_array)) {


### PR DESCRIPTION
- The error we made was that an 'internal post' occurred only if there are dynamic values and apparently this is not the only situation where an internal post should happen. User can set even a calculate item that does not require a dynamic value.
- This commit just moves that aspect out of Survey::parseShowIfsAndDynamicValues()