### PR TITLE
Setting paragonie/halite dependency to '*' and leave it up to composer

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
         "bshaffer/oauth2-server-php": "~1.7",
         "atrox/haikunator": "^1.0",
         "mhlavac/gearman": "dev-master",
-		"paragonie/halite": "^v1"
+	"paragonie/halite": "*"
     },
     "require-dev": {
         "phpunit/phpunit": "3.7.*"


### PR DESCRIPTION
to install the newest compatible version.

Things to keep in mind:
php5.6 requires halite 1.x
php7.0 requires halite ≥2.0 but halite 2.x doesn't work with current version of libsodium anymore, so in fact you'll need halite 3.x.
php7.2 requires halite 4.x

composer will install the newest possible library version. Alternativly php5.6 support could be dropped and halite could be set to '>=3.4'.

To support the newest versions (1.0.13+) of libsodium, one should use the newest
version of halite. Actually the used php version limits the halite version,
not the other way around.

So a '*' should be the right dependency rule.