### PR TITLE
Allow sending emails without authentification.

### DIFF
--- a/application/Library/EmailQueue.php
+++ b/application/Library/EmailQueue.php
@@ -123,9 +123,13 @@ class EmailQueue {
 			} else {
 				$mail->SMTPSecure = 'ssl';
 			}
-			$mail->Username = $account['username'];
-			$mail->Password = $account['password'];
-
+			if (isset($account['username'])) {
+				$mail->Username = $account['username'];
+				$mail->Password = $account['password'];
+			} else {
+				$mail->SMTPAuth = false;
+				$mail->SMTPSecure = false;
+			}
 			$mail->setFrom($account['from'], $account['from_name']);
 			$mail->AddReplyTo($account['from'], $account['from_name']);
 			$mail->CharSet = "utf-8";

--- a/application/Model/EmailAccount.php
+++ b/application/Model/EmailAccount.php
@@ -107,10 +107,14 @@ class EmailAccount {
 		} else {
 			$mail->SMTPSecure = 'ssl';
 		}
-		$mail->SMTPAuth = true; // turn on SMTP authentication
-		$mail->Username = $this->account['username']; // SMTP username
-		$mail->Password = $this->account['password']; // SMTP password
-
+		if (isset($this->account['username'])) {
+			$mail->SMTPAuth = true; // turn on SMTP authentication
+			$mail->Username = $this->account['username']; // SMTP username
+			$mail->Password = $this->account['password']; // SMTP password
+		} else {
+			$mail->SMTPAuth = false; 
+			$mail->SMTPSecure = false;
+		}	
 		$mail->From = $this->account['from'];
 		$mail->FromName = $this->account['from_name'];
 		$mail->AddReplyTo($this->account['from'], $this->account['from_name']);

--- a/application/Model/Site.php
+++ b/application/Model/Site.php
@@ -130,10 +130,14 @@ class Site {
 		} else {
 			$mail->SMTPSecure = 'ssl';
 		}
-		$mail->SMTPAuth = true; // turn on SMTP authentication
-		$mail->Username = $settings['email']['username']; // SMTP username
-		$mail->Password = $settings['email']['password']; // SMTP password
-
+		if (isset($settings['email']['username'])) {
+			$mail->SMTPAuth = true; // turn on SMTP authentication
+			$mail->Username = $settings['email']['username']; // SMTP username
+			$mail->Password = $settings['email']['password']; // SMTP password
+		} else {
+			$mail->SMTPAuth = false;
+			$mail->SMTPSecure = false;
+		}
 		$mail->From = $settings['email']['from'];
 		$mail->FromName = $settings['email']['from_name'];
 		$mail->AddReplyTo($settings['email']['from'], $settings['email']['from_name']);


### PR DESCRIPTION
This might be relevant for setups at e. g. universities, where email sending is bind to source ip addresses and no account is required.