### PR TITLE
Fix Google Spreadsheet import on PHP7.2.

### DIFF
--- a/application/Library/CURL.php
+++ b/application/Library/CURL.php
@@ -315,7 +315,7 @@ class CURL {
 			touch($tmpfile, $last_modified);
 		}
 
-		$res = rename($tmpfile, $output_file);
+		$res = \rename($tmpfile, $output_file);
 		if ($res !== true) {
 			throw new Exception("Unable to rename temporary file");
 		}


### PR DESCRIPTION
Somehow the rename function does return NULL now where formr expects it to return TRUE (line 319).

I documented this weird behavior here: https://stackoverflow.com/questions/51668723/rename-gives-undocumented-return-value-null

I don't have an explanation so far, why PHP7.2 changed the behavior compared to PHP7.0 as it runs on formr.org. But this occurred to me on CentOS with self-compiled PHP7.2 and on Ubuntu 18.04 with standard PHP7.2.

Maybe @rubenarslan can test it on his recently installed instance aswell.