### PR TITLE
fix: the variable name check is not doing what the error message tells the user

### DIFF
--- a/application/Spreadsheet/SpreadsheetReader.php
+++ b/application/Spreadsheet/SpreadsheetReader.php
@@ -743,7 +743,7 @@ class SpreadsheetReader {
                         }
                         unset($data[$rowNumber]);
                         continue 2; // Skip row with no item name
-                    } elseif (!preg_match('/^[a-zA-Z][a-zA-Z0-9_]{1,64}$/', $cellValue)) {
+                    } elseif (!preg_match('/^[a-zA-Z][a-zA-Z0-9_]{0,63}$/', $cellValue)) {
                         $this->errors[] = __("The variable name '%s' is invalid. It has to be between 1 and 64 characters. It needs to start with a letter and can only contain the characters from <strong>a</strong> to <strong>Z</strong>, <strong>0</strong> to <strong>9</strong> and the underscore.", $cellValue);
                     }
 


### PR DESCRIPTION
Currently the regex evaluates if a variable name has 2 letters. 

*before*: The first square brackets test if the `name` starts with a letter, so we have 1 character. The second square brackets test if there are 1-64 alpha_numerical characters. The in sum 2..65.
*after*: The first square brackets test if the `name` starts with a letter, so we have 1 character. The second square brackets test if there are 0-63 alpha_numerical characters. The in sum 1..64.