### PR TITLE
api: enforce scope checks for run write operations POST and PATCH

### DIFF
--- a/application/Api/V1/RunResource.php
+++ b/application/Api/V1/RunResource.php
@@ -79,7 +79,11 @@ class RunResource extends BaseResource
         // for unauthorized callers, which is misleading and inconsistent.
         switch ($method) {
             case 'POST':
+                $this->checkScope('run:write');
+                break;
             case 'PATCH':
+                $this->checkScope('run:write');
+                break;
             case 'DELETE':
                 $this->checkScope('run:write');
                 break;


### PR DESCRIPTION
just noticed that the run actions missed two scope "run:write" checks; this adds them to the SWITCH statement.