### PR TITLE
UX improvements to API Credentials page

### DIFF
--- a/templates/admin/account/index.php
+++ b/templates/admin/account/index.php
@@ -188,7 +188,7 @@ remotes::install_github("rubenarslan/formr")</code></pre>
                                     </table>
                                 </div>
 
-                                <h4 class="lead" style="margin-top: 30px;">Create a new credential</h4>
+                                <h4 id="api-form-heading" class="lead" style="margin-top: 30px;">Create a new credential</h4>
                                 <div class="api-form" data-form-mode="create">
                                     <div class="row">
                                         <div class="col-md-8">
@@ -298,6 +298,7 @@ remotes::install_github("rubenarslan/formr")</code></pre>
                             var $submitLabel = $panel.find('.api-submit-label');
                             var $cancelBtn = $panel.find('#api-cancel-rotate-btn');
                             var $labelInput = $panel.find('#api-label-input');
+                            var $formHeading = $panel.find('#api-form-heading');
                             // rotate state — when non-null the form submits a rotate
                             // for this client_id (label is fixed and disabled).
                             var rotateClientId = null;
@@ -328,6 +329,7 @@ remotes::install_github("rubenarslan/formr")</code></pre>
                                 $submitLabel.text('Create credential');
                                 $submitBtn.removeClass('btn-warning').addClass('btn-primary');
                                 $cancelBtn.hide();
+                                $formHeading.text('Create a new credential');
                                 $form.find('input[name="api_scope[]"]').prop('checked', false);
                                 $panel.find('#api-scope-select-all').prop('checked', false);
                                 $form.find('select[name="api_run_ids[]"] option:selected').prop('selected', false);
@@ -342,6 +344,7 @@ remotes::install_github("rubenarslan/formr")</code></pre>
                                 $submitLabel.text('Rotate secret for "' + label + '"');
                                 $submitBtn.removeClass('btn-primary').addClass('btn-warning');
                                 $cancelBtn.show();
+                                $formHeading.text('Rotate credential');
                                 $form.find('input[name="api_scope[]"]').each(function () {
                                     this.checked = scopes.indexOf(this.value) !== -1;
                                 });
@@ -368,6 +371,14 @@ remotes::install_github("rubenarslan/formr")</code></pre>
                                     var label = jQuery.trim($labelInput.val());
                                     if (!label) {
                                         alert('Please pick a label for this credential.');
+                                        return;
+                                    }
+                                    var existingLabels = $panel.find('.api-credentials-list tbody tr').map(function () {
+                                        return jQuery(this).data('label');
+                                    }).get();
+                                    if (existingLabels.some(function (l) { return l.toLowerCase() === label.toLowerCase(); })) {
+                                        alert('You already have a credential with the label "' + label + '". Each label must be unique within your account.');
+                                        $submitBtn.prop('disabled', false);
                                         return;
                                     }
                                     payload = jQuery.extend({ api_action: 'create', label: label }, sel);

--- a/templates/admin/account/index.php
+++ b/templates/admin/account/index.php
@@ -422,7 +422,13 @@ remotes::install_github("rubenarslan/formr")</code></pre>
                                     dataType: 'json'
                                 }).done(function (response) {
                                     if (response && response.success) {
+                                        var $tbody = $row.closest('tbody');
                                         $row.remove();
+                                        if (0 === $tbody.children('tr').length) {
+                                            $tbody.closest('table').replaceWith(
+                                                '<p class="text-muted"><em>You have no API credentials yet. Create one below.</em></p>'
+                                            );
+                                        }
                                         if (clientId === rotateClientId) enterCreateMode();
                                     } else {
                                         alert((response && response.message) || 'Could not delete credential.');

--- a/templates/admin/account/index.php
+++ b/templates/admin/account/index.php
@@ -398,7 +398,7 @@ remotes::install_github("rubenarslan/formr")</code></pre>
                                     var $table = $panel.find('.api-credentials-list');
                                     var scopeHtml = sel.scope.length === 0
                                         ? '<em class="text-muted">none \u2014 token cannot access API</em>'
-                                        : sel.scope.map(function (s) { return '<code style="margin-right: 4px;">' + escAttr(s) + '</code>'; }).join('');
+                                        : sel.scope.map(function (s) { return '<code style="margin-right: 4px;">' + escAttr(s) + '</code>'; }).join(' ');
                                     var runHtml = sel.run_ids.length === 0
                                         ? '<em class="text-muted">all</em>'
                                         : sel.run_ids.length + ' selected';

--- a/templates/admin/account/index.php
+++ b/templates/admin/account/index.php
@@ -366,8 +366,8 @@ remotes::install_github("rubenarslan/formr")</code></pre>
                                     && !confirm('You have not selected any scopes. A token with no scopes cannot access the API. Continue anyway?')) {
                                     return;
                                 }
-                                var payload;
-                                if (rotateClientId === null) {
+                                var wasCreate = (rotateClientId === null);
+                                if (wasCreate) {
                                     var label = jQuery.trim($labelInput.val());
                                     if (!label) {
                                         alert('Please pick a label for this credential.');
@@ -404,36 +404,41 @@ remotes::install_github("rubenarslan/formr")</code></pre>
                                     $panel.find('.api-out-r-cmd').text(rCommand(response.data.client_id, response.data.client_secret));
                                     $panel.find('#api-secret-once').removeClass('hidden');
 
-                                    // Dynamically add the new row to the credentials table
-                                    var escAttr = function (s) { return jQuery('<div>').text(s).html(); };
-                                    var $table = $panel.find('.api-credentials-list');
-                                    var scopeHtml = sel.scope.length === 0
-                                        ? '<em class="text-muted">none \u2014 token cannot access API</em>'
-                                        : sel.scope.map(function (s) { return '<code style="margin-right: 4px;">' + escAttr(s) + '</code>'; }).join(' ');
-                                    var runHtml = sel.run_ids.length === 0
-                                        ? '<em class="text-muted">all</em>'
-                                        : sel.run_ids.length + ' selected';
-                                    var rowHtml = '<tr data-client-id="' + escAttr(response.data.client_id) + '" data-label="' + escAttr(response.data.label) + '">'
-                                        + '<td><strong>' + escAttr(response.data.label) + '</strong></td>'
-                                        + '<td><code>' + escAttr(response.data.client_id) + '</code></td>'
-                                        + '<td>' + scopeHtml + '</td>'
-                                        + '<td>' + runHtml + '</td>'
-                                        + '<td>'
-                                        + '<button type="button" class="btn btn-warning btn-xs api-rotate-btn"><i class="fa fa-refresh"></i> Rotate</button> '
-                                        + '<button type="button" class="btn btn-danger btn-xs api-delete-btn"><i class="fa fa-trash"></i> Delete</button>'
-                                        + '</td>'
-                                        + '</tr>';
-                                    if ($table.length === 0) {
-                                        $panel.find('h4.lead:contains("Your credentials") ~ p.text-muted').remove();
-                                        $panel.find('h4.lead:contains("Your credentials")').after(
-                                            '<table class="table table-bordered api-credentials-list">'
-                                            + '<thead><tr><th>Label</th><th>Client ID</th><th>Scopes</th><th>Runs</th><th></th></tr></thead>'
-                                            + '<tbody>' + rowHtml + '</tbody>'
-                                            + '</table>'
-                                        );
-                                    } else {
-                                        $table.find('tbody').prepend(rowHtml);
+                                    if (wasCreate) {
+                                        // Dynamically add the new row to the credentials table
+                                        var escAttr = function (s) { return jQuery('<div>').text(s).html(); };
+                                        var $table = $panel.find('.api-credentials-list');
+                                        var scopeHtml = sel.scope.length === 0
+                                            ? '<em class="text-muted">none \u2014 token cannot access API</em>'
+                                            : sel.scope.map(function (s) { return '<code style="margin-right: 4px;">' + escAttr(s) + '</code>'; }).join(' ');
+                                        var runHtml = sel.run_ids.length === 0
+                                            ? '<em class="text-muted">all</em>'
+                                            : sel.run_ids.length + ' selected';
+                                        var rowHtml = '<tr data-client-id="' + escAttr(response.data.client_id) + '" data-label="' + escAttr(response.data.label) + '">'
+                                            + '<td><strong>' + escAttr(response.data.label) + '</strong></td>'
+                                            + '<td><code>' + escAttr(response.data.client_id) + '</code></td>'
+                                            + '<td>' + scopeHtml + '</td>'
+                                            + '<td>' + runHtml + '</td>'
+                                            + '<td>'
+                                            + '<button type="button" class="btn btn-warning btn-xs api-rotate-btn"><i class="fa fa-refresh"></i> Rotate</button> '
+                                            + '<button type="button" class="btn btn-danger btn-xs api-delete-btn"><i class="fa fa-trash"></i> Delete</button>'
+                                            + '</td>'
+                                            + '</tr>';
+                                        if ($table.length === 0) {
+                                            $panel.find('h4.lead:contains("Your credentials") ~ p.text-muted').remove();
+                                            $panel.find('h4.lead:contains("Your credentials")').after(
+                                                '<table class="table table-bordered api-credentials-list">'
+                                                + '<thead><tr><th>Label</th><th>Client ID</th><th>Scopes</th><th>Runs</th><th></th></tr></thead>'
+                                                + '<tbody>' + rowHtml + '</tbody>'
+                                                + '</table>'
+                                            );
+                                        } else {
+                                            $table.find('tbody').prepend(rowHtml);
+                                        }
                                     }
+                                    // Reset form back to create mode, keeping the secret visible
+                                    enterCreateMode();
+                                    $panel.find('#api-secret-once').removeClass('hidden');
                                 }).fail(function () {
                                     alert('Request failed.');
                                     $submitBtn.prop('disabled', false);

--- a/templates/admin/account/index.php
+++ b/templates/admin/account/index.php
@@ -145,7 +145,7 @@ remotes::install_github("rubenarslan/formr")</code></pre>
                                         </thead>
                                         <tbody>
                                         <?php foreach ($api_credentials_list as $cred): ?>
-                                            <tr data-client-id="<?= h($cred['client_id']) ?>" data-label="<?= h($cred['label']) ?>">
+                                            <tr data-client-id="<?= h($cred['client_id']) ?>" data-label="<?= h($cred['label']) ?>" data-run-ids="<?= h(implode(',', $cred['run_ids'])) ?>">
                                                 <td><strong><?= h($cred['label']) ?></strong></td>
                                                 <td><code><?= h($cred['client_id']) ?></code></td>
                                                 <td>
@@ -169,6 +169,9 @@ remotes::install_github("rubenarslan/formr")</code></pre>
                                 <?php endif; ?>
 
                                 <div id="api-secret-once" class="hidden" style="margin-top: 20px;">
+                                    <div class="alert alert-success" id="api-secret-success" style="margin-bottom: 10px;">
+                                        <strong>Credential created successfully.</strong>
+                                    </div>
                                     <div class="alert alert-warning">
                                         <strong>One-time display.</strong> Copy the client secret now — we only store a hash, so it cannot be recovered later.
                                     </div>
@@ -256,10 +259,11 @@ remotes::install_github("rubenarslan/formr")</code></pre>
                                                     <p class="text-muted"><em>You have no runs yet.</em></p>
                                                 <?php else: ?>
                                                     <select name="api_run_ids[]" multiple class="form-control" size="<?= min(8, max(3, count($user_runs))) ?>" style="width: 100%;">
-                                                        <?php foreach ($user_runs as $run_row): ?>
-                                                            <option value="<?= (int) $run_row['id'] ?>"><?= h($run_row['name']) ?></option>
-                                                        <?php endforeach; ?>
-                                                    </select>
+                                                         <?php foreach ($user_runs as $run_row): ?>
+                                                             <option value="<?= (int) $run_row['id'] ?>"><?= h($run_row['name']) ?></option>
+                                                         <?php endforeach; ?>
+                                                     </select>
+                                                     <p class="help-block" style="margin-top: 4px;"><a href="#" class="api-clear-runs">Clear selection</a></p>
                                                 <?php endif; ?>
                                             </fieldset>
                                         </div>
@@ -402,19 +406,23 @@ remotes::install_github("rubenarslan/formr")</code></pre>
                                     $panel.find('.api-out-client-id').text(response.data.client_id);
                                     $panel.find('.api-out-client-secret').text(response.data.client_secret);
                                     $panel.find('.api-out-r-cmd').text(rCommand(response.data.client_id, response.data.client_secret));
+                                    $panel.find('#api-secret-success').text(
+                                        wasCreate ? 'Credential created successfully.' : 'Secret rotated successfully. The old secret is now invalid.'
+                                    );
                                     $panel.find('#api-secret-once').removeClass('hidden');
+
+                                    var escAttr = function (s) { return jQuery('<div>').text(s).html(); };
+                                    var scopeHtml = sel.scope.length === 0
+                                        ? '<em class="text-muted">none \u2014 token cannot access API</em>'
+                                        : sel.scope.map(function (s) { return '<code style="margin-right: 4px;">' + escAttr(s) + '</code>'; }).join(' ');
+                                    var runHtml = sel.run_ids.length === 0
+                                        ? '<em class="text-muted">all</em>'
+                                        : sel.run_ids.length + ' selected';
 
                                     if (wasCreate) {
                                         // Dynamically add the new row to the credentials table
-                                        var escAttr = function (s) { return jQuery('<div>').text(s).html(); };
                                         var $table = $panel.find('.api-credentials-list');
-                                        var scopeHtml = sel.scope.length === 0
-                                            ? '<em class="text-muted">none \u2014 token cannot access API</em>'
-                                            : sel.scope.map(function (s) { return '<code style="margin-right: 4px;">' + escAttr(s) + '</code>'; }).join(' ');
-                                        var runHtml = sel.run_ids.length === 0
-                                            ? '<em class="text-muted">all</em>'
-                                            : sel.run_ids.length + ' selected';
-                                        var rowHtml = '<tr data-client-id="' + escAttr(response.data.client_id) + '" data-label="' + escAttr(response.data.label) + '">'
+                                        var rowHtml = '<tr data-client-id="' + escAttr(response.data.client_id) + '" data-label="' + escAttr(response.data.label) + '" data-run-ids="' + escAttr(sel.run_ids.join(',')) + '">'
                                             + '<td><strong>' + escAttr(response.data.label) + '</strong></td>'
                                             + '<td><code>' + escAttr(response.data.client_id) + '</code></td>'
                                             + '<td>' + scopeHtml + '</td>'
@@ -435,6 +443,14 @@ remotes::install_github("rubenarslan/formr")</code></pre>
                                         } else {
                                             $table.find('tbody').prepend(rowHtml);
                                         }
+                                    } else {
+                                        // Update the existing row with the new scopes/runs
+                                        var $row = $panel.find('.api-credentials-list tr[data-client-id="' + escAttr(rotateClientId) + '"]');
+                                        if ($row.length) {
+                                            $row.attr('data-run-ids', sel.run_ids.join(','));
+                                            $row.find('td:eq(2)').html(scopeHtml);
+                                            $row.find('td:eq(3)').html(runHtml);
+                                        }
                                     }
                                     // Reset form back to create mode, keeping the secret visible
                                     enterCreateMode();
@@ -454,7 +470,7 @@ remotes::install_github("rubenarslan/formr")</code></pre>
                                 // The row only shows a count of runs, not the actual ids — leave runs unselected
                                 // and the user can re-pick. (Keeping the previous allowlist would require an extra
                                 // round-trip.)
-                                enterRotateMode(clientId, label, scopes, []);
+                                enterRotateMode(clientId, label, scopes, ($row.attr('data-run-ids') || '').split(',').filter(Boolean).map(Number));
                             });
                             $panel.on('click', '.api-delete-btn', function () {
                                 var $row = jQuery(this).closest('tr');
@@ -483,6 +499,10 @@ remotes::install_github("rubenarslan/formr")</code></pre>
                             });
                             $panel.on('click', '#api-create-btn', submitForm);
                             $panel.on('click', '#api-cancel-rotate-btn', enterCreateMode);
+                            $panel.on('click', '.api-clear-runs', function (e) {
+                                e.preventDefault();
+                                $form.find('select[name="api_run_ids[]"] option').prop('selected', false);
+                            });
 
                             // "Select all" toggles every scope checkbox
                             $panel.on('change', '#api-scope-select-all', function () {

--- a/templates/admin/account/index.php
+++ b/templates/admin/account/index.php
@@ -392,7 +392,37 @@ remotes::install_github("rubenarslan/formr")</code></pre>
                                     $panel.find('.api-out-client-secret').text(response.data.client_secret);
                                     $panel.find('.api-out-r-cmd').text(rCommand(response.data.client_id, response.data.client_secret));
                                     $panel.find('#api-secret-once').removeClass('hidden');
-                                    reloadAfter(60000); // reload after a minute so the list refreshes
+
+                                    // Dynamically add the new row to the credentials table
+                                    var escAttr = function (s) { return jQuery('<div>').text(s).html(); };
+                                    var $table = $panel.find('.api-credentials-list');
+                                    var scopeHtml = sel.scope.length === 0
+                                        ? '<em class="text-muted">none \u2014 token cannot access API</em>'
+                                        : sel.scope.map(function (s) { return '<code style="margin-right: 4px;">' + escAttr(s) + '</code>'; }).join('');
+                                    var runHtml = sel.run_ids.length === 0
+                                        ? '<em class="text-muted">all</em>'
+                                        : sel.run_ids.length + ' selected';
+                                    var rowHtml = '<tr data-client-id="' + escAttr(response.data.client_id) + '" data-label="' + escAttr(response.data.label) + '">'
+                                        + '<td><strong>' + escAttr(response.data.label) + '</strong></td>'
+                                        + '<td><code>' + escAttr(response.data.client_id) + '</code></td>'
+                                        + '<td>' + scopeHtml + '</td>'
+                                        + '<td>' + runHtml + '</td>'
+                                        + '<td>'
+                                        + '<button type="button" class="btn btn-warning btn-xs api-rotate-btn"><i class="fa fa-refresh"></i> Rotate</button> '
+                                        + '<button type="button" class="btn btn-danger btn-xs api-delete-btn"><i class="fa fa-trash"></i> Delete</button>'
+                                        + '</td>'
+                                        + '</tr>';
+                                    if ($table.length === 0) {
+                                        $panel.find('h4.lead:contains("Your credentials") ~ p.text-muted').remove();
+                                        $panel.find('h4.lead:contains("Your credentials")').after(
+                                            '<table class="table table-bordered api-credentials-list">'
+                                            + '<thead><tr><th>Label</th><th>Client ID</th><th>Scopes</th><th>Runs</th><th></th></tr></thead>'
+                                            + '<tbody>' + rowHtml + '</tbody>'
+                                            + '</table>'
+                                        );
+                                    } else {
+                                        $table.find('tbody').prepend(rowHtml);
+                                    }
                                 }).fail(function () {
                                     alert('Request failed.');
                                     $submitBtn.prop('disabled', false);

--- a/webroot/assets/admin/css/style.css
+++ b/webroot/assets/admin/css/style.css
@@ -324,3 +324,6 @@ body.skin-black .content-wrapper {
     right: -100px;
     top: -40px;
 }
+.api-credentials-list td:first-child {
+    word-break: break-word;
+}


### PR DESCRIPTION
**Problems fixed**
- No empty state: Deleting the last credential left an empty table with no message
- Table didn't update on create/rotate: Creating a credential required a page reload to see it; rotating with changed scopes/runs showed stale data until reload
- Run selections lost on rotate: The rotate form always cleared the run multiselect, forcing users to re-pick
- No success feedback: After rotate, there was no confirmation — the secret box just appeared
- Stuck in rotate mode: After a successful rotation, the form stayed in rotate mode until the user clicked Cancel
- Label overflow: Long labels pushed the table past its container on narrow screens
- Duplicate label (silent 500): Submitting a duplicate label hit a DB constraint and showed a generic error
- No way to clear run selection: Once a run was selected, users had to Cmd+click each one to deselect

**Changes**
templates/admin/account/index.php
- Store run_ids as data-run-ids on each table row, and restore them into the multiselect when entering rotate mode
- After rotation, update the existing row's scopes/runs columns in-place instead of requiring a reload
- Add success banner with context-aware text ("Credential created successfully." / "Secret rotated successfully.")
- After create/rotate, reset the form back to create mode automatically (heading, label, button, cancel button)
- Add "Clear selection" link below the runs multiselect to easily reset to "all runs"
- Add client-side label uniqueness check to prevent the silent DB constraint error
- Add id="api-form-heading" so the heading can be changed dynamically

webroot/assets/admin/css/style.css
- Add word-break: break-word on the label column so long labels wrap instead of overflowing

**Bug fix**
- Use .attr() instead of .data() when reading data-run-ids — jQuery's .data() auto-converts "3" to the number 3, causing .split() to fail silently for credentials with exactly one run