### PR TITLE
Feature: custom r functions and secrets

### DIFF
--- a/application/Api/V1/RunResource.php
+++ b/application/Api/V1/RunResource.php
@@ -207,7 +207,7 @@ class RunResource extends BaseResource
             'expire_cookie_unit' => $run->expire_cookie_unit,
             'custom_css' => $run->getCustomCSS(),
             'custom_js' => $run->getCustomJS(),
-            'custom_r' => $run->getCustomRFunctions(),
+            'custom_r' => opencpu_redact_secrets($run->getCustomRFunctions(), $run->getCustomRFunctions()),
             'manifest_json' => $run->getManifestJSON(),
         ];
 

--- a/application/Api/V1/RunResource.php
+++ b/application/Api/V1/RunResource.php
@@ -13,7 +13,7 @@ class RunResource extends BaseResource
     private static $updatableFields = [
         'title', 'description', 'footer_text', 'public_blurb',
         'privacy', 'tos', 'header_image_path', 'custom_css',
-        'custom_js', 'cron_active',
+        'custom_js', 'custom_r', 'cron_active',
         'use_material_design', 'expiresOn',
         'expire_cookie_value', 'expire_cookie_unit',
         'public', 'locked',
@@ -207,6 +207,7 @@ class RunResource extends BaseResource
             'expire_cookie_unit' => $run->expire_cookie_unit,
             'custom_css' => $run->getCustomCSS(),
             'custom_js' => $run->getCustomJS(),
+            'custom_r' => $run->getCustomRFunctions(),
             'manifest_json' => $run->getManifestJSON(),
         ];
 

--- a/application/Api/V1/RunResource.php
+++ b/application/Api/V1/RunResource.php
@@ -207,7 +207,7 @@ class RunResource extends BaseResource
             'expire_cookie_unit' => $run->expire_cookie_unit,
             'custom_css' => $run->getCustomCSS(),
             'custom_js' => $run->getCustomJS(),
-            'custom_r' => opencpu_redact_secrets($run->getCustomRFunctions(), $run->getCustomRFunctions()),
+            'custom_r' => $run->getCustomRFunctions(),
             'manifest_json' => $run->getManifestJSON(),
         ];
 

--- a/application/Controller/AdminAjaxController.php
+++ b/application/Controller/AdminAjaxController.php
@@ -567,6 +567,22 @@ class AdminAjaxController {
         return $this->response->setContent($content);
     }
 
+    private function ajaxValidateRCode() {
+        if (!Request::isAjaxRequest()) {
+            formr_error(406, 'Not Acceptable');
+        }
+
+        $code = $this->request->getParam('r_code');
+        if ($code === null) {
+            return $this->response->setJsonContent([
+                'valid' => false,
+                'message' => 'No R code provided.',
+            ]);
+        }
+
+        return $this->response->setJsonContent(opencpu_validate_r_code($code));
+    }
+
     private function ajaxTestUnit() {
         if (!Request::isAjaxRequest()) {
             formr_error(406, 'Not Acceptable');

--- a/application/Controller/AdminRunController.php
+++ b/application/Controller/AdminRunController.php
@@ -685,14 +685,15 @@ class AdminRunController extends AdminController
 
     private function createRunUnitAction()
     {
-        $redirect = $this->request->redirect ? admin_run_url($this->run->name, $this->request->redirect) : admin_run_url($this->run->name);
+        $redirectTarget = $this->request->redirect ? str_replace(':::', '#', $this->request->redirect) : '';
+        $redirect = $redirectTarget ? admin_run_url($this->run->name, $redirectTarget) : admin_run_url($this->run->name);
         $unit = $this->createRunUnit();
         if ($unit->valid) {
             alert('Run unit created', 'alert-success');
         } else {
             alert('An unexpected error occured. Unit could not be created', 'alert-danger');
         }
-        $this->request->redirect(str_replace(':::', '#', $redirect));
+        $this->request->redirect($redirect);
     }
 
     private function deleteRunUnitAction()
@@ -701,7 +702,8 @@ class AdminRunController extends AdminController
         if (!$id) {
             throw new Exception('Missing Parameter');
         }
-        $redirect = $this->request->redirect ? admin_run_url($this->run->name, $this->request->redirect) : admin_run_url($this->run->name);
+        $redirectTarget = $this->request->redirect ? str_replace(':::', '#', $this->request->redirect) : '';
+        $redirect = $redirectTarget ? admin_run_url($this->run->name, $redirectTarget) : admin_run_url($this->run->name);
         $unit = $this->createRunUnit($id);
         if ($unit->valid) {
             $unit->run_unit_id = $id;
@@ -710,7 +712,7 @@ class AdminRunController extends AdminController
         } else {
             alert('An unexpected error occured. Unit could not be deleted', 'alert-danger');
         }
-        $this->request->redirect(str_replace(':::', '#', $redirect));
+        $this->request->redirect($redirect);
     }
 
     private function panicAction()

--- a/application/Functions.php
+++ b/application/Functions.php
@@ -1233,6 +1233,23 @@ function opencpu_prepare_api_access($code, &$variables)
 }
 
 /**
+ * Get the custom R functions defined for the currently active run.
+ * Relies on the Run model's instance-level cache so the file is read
+ * at most once per request.
+ */
+function opencpu_custom_r()
+{
+    $run_session = Site::getInstance()->getRunSession();
+    if ($run_session) {
+        $run = $run_session->getRun();
+        if ($run) {
+            return $run->getCustomRFunctions();
+        }
+    }
+    return '';
+}
+
+/**
  * Execute a piece of code against OpenCPU
  *
  * @param string $code Each code line should be separated by a newline characted
@@ -1252,9 +1269,12 @@ function opencpu_evaluate($code, $variables = null, $return_format = 'json', $co
 
     $r_variables = is_string($variables) ? $variables : opencpu_define_vars($variables, $context);
 
+    $custom_r = opencpu_custom_r();
+
     $params = ['x' => '{ 
 (function() {
 	library(formr)
+	' . ($custom_r ? $custom_r . "\n" : '') . '
 	' . $r_variables . '
 	' . $code . '
 })() }'];
@@ -1348,8 +1368,11 @@ function opencpu_knit_plaintext($source, $variables = null, $return_session = fa
         $show_warnings = 'TRUE';
     }
 
+    $custom_r = opencpu_custom_r();
+
     $source = '```{r settings,warning=' . $show_warnings . ',message=' . $show_warnings . ',error=' . $show_errors . ',echo=F}
 library(knitr); library(formr)
+' . ($custom_r ? $custom_r . "\n" : '') . '
 opts_chunk$set(warning=' . $show_warnings . ',message=' . $show_warnings . ',error=' . $show_errors . ',echo=F,fig.height=7,fig.width=10)
 opts_knit$set(base.url="' . OpenCPU::TEMP_BASE_URL . '")
 ' . $variables . '
@@ -1451,6 +1474,8 @@ function opencpu_knit_iframe($source, $variables = null, $return_session = false
         $source = $parts[2];
     }
 
+    $custom_r = opencpu_custom_r();
+
     // include=FALSE on the settings chunk: the chunk's R code still runs
     // (library() / opts_chunk$set() / variable assignments), but the chunk
     // source never lands in the rendered output. This matters because
@@ -1464,6 +1489,7 @@ function opencpu_knit_iframe($source, $variables = null, $return_session = false
     $source = $yaml .
         '```{r settings,include=FALSE}
 library(knitr); library(formr)
+' . ($custom_r ? $custom_r . "\n" : '') . '
 opts_chunk$set(warning=' . $show_warnings . ',message=' . $show_warnings . ',error=' . $show_errors . ',echo=' . $show_warnings . ',fig.height=7,fig.width=10)
 ' . $variables . '
 ```
@@ -1519,8 +1545,11 @@ function opencpu_knitdisplay($source, $variables = null, $return_session = false
         $show_warnings = 'TRUE';
     }
 
+    $custom_r = opencpu_custom_r();
+
     $source = '```{r settings,warning=' . $show_warnings . ',message=' . $show_warnings . ',error=' . $show_errors . ',echo=F}
 library(knitr); library(formr)
+' . ($custom_r ? $custom_r . "\n" : '') . '
 opts_chunk$set(warning=' . $show_warnings . ',message=' . $show_warnings . ',error=' . $show_errors . ',echo=F,fig.height=7,fig.width=10)
 opts_knit$set(base.url="' . OpenCPU::TEMP_BASE_URL . '")
 ' . $variables . '
@@ -1553,8 +1582,11 @@ function opencpu_knitadmin($source, $variables = null, $return_session = false)
         $show_warnings = 'TRUE';
     }
 
+    $custom_r = opencpu_custom_r();
+
     $source = '```{r settings,warning=' . $show_warnings . ',message=' . $show_warnings . ',error=' . $show_errors . ',echo=F}
 library(knitr); library(formr)
+' . ($custom_r ? $custom_r . "\n" : '') . '
 opts_chunk$set(warning=' . $show_warnings . ',message=' . $show_warnings . ',error=' . $show_errors . ',echo=F)
 opts_knit$set(base.url="' . OpenCPU::TEMP_BASE_URL . '")
 ' . $variables . '
@@ -1586,8 +1618,11 @@ function opencpu_knit_email($source, array $variables = null, $return_format = '
         $show_warnings = 'TRUE';
     }
 
+    $custom_r = opencpu_custom_r();
+
     $source = '```{r settings,warning=' . $show_warnings . ',message=' . $show_warnings . ',error=' . $show_errors . ',echo=F}
 library(knitr); library(formr)
+' . ($custom_r ? $custom_r . "\n" : '') . '
 opts_chunk$set(warning=' . $show_warnings . ',message=' . $show_warnings . ',error=' . $show_errors . ',echo=F,fig.retina=2)
 opts_knit$set(upload.fun=function(x) { paste0("cid:", URLencode(basename(x))) })
 ' . $variables . '

--- a/application/Functions.php
+++ b/application/Functions.php
@@ -1250,41 +1250,51 @@ function opencpu_custom_r()
 }
 
 /**
- * Parse custom R code for secret variable definitions.
- * Matches assignment patterns like secret_<name> <- "value" or secret_<name> = 'value'.
- * Only captures string literals (not expressions or function calls).
+ * Get secrets defined for the currently active run.
+ * Loaded from the survey_run_secrets table, decrypted via Crypto.
  *
- * @param string $r_code The R source code to scan
- * @return array Associative array of [var_name => raw_value]
+ * @return array Associative array of [name => plaintext_value]
  */
-function opencpu_extract_secrets($r_code)
+function opencpu_secrets()
 {
-    $secrets = [];
-    if (empty($r_code)) {
-        return $secrets;
+    $run_session = Site::getInstance()->getRunSession();
+    if ($run_session) {
+        $run = $run_session->getRun();
+        if ($run) {
+            return $run->getSecrets();
+        }
     }
 
-    preg_match_all(
-        '/^[ \t]*secret_([a-zA-Z_][a-zA-Z0-9_.]*)\s*(?:<-|=)\s*"((?:[^"\\\\]|\\\\.)*)"\s*(?:#.*)?$/m',
-        $r_code,
-        $matches,
-        PREG_SET_ORDER
-    );
-    foreach ($matches as $m) {
-        $secrets['secret_' . $m[1]] = r_unescape($m[2]);
+    return [];
+}
+
+/**
+ * Generate R code to inject secrets as .formr$ variables.
+ *
+ * Secrets are assigned to the hidden .formr$ environment so they are
+ * accessible in R as .formr$secret_<name> but do not appear in ls()
+ * output or pollute the global scope.
+ *
+ * @param array|null $secrets Optional secrets array; if null loaded from run
+ * @return string R code assigning each secret
+ */
+function opencpu_inject_secrets($secrets = null)
+{
+    if ($secrets === null) {
+        $secrets = opencpu_secrets();
     }
 
-    preg_match_all(
-        "/^[ \t]*secret_([a-zA-Z_][a-zA-Z0-9_.]*)\s*(?:<-|=)\s*'((?:[^'\\\\]|\\\\.)*)'\s*(?:#.*)?$/m",
-        $r_code,
-        $matches,
-        PREG_SET_ORDER
-    );
-    foreach ($matches as $m) {
-        $secrets['secret_' . $m[1]] = r_unescape($m[2]);
+    if (empty($secrets)) {
+        return '';
     }
 
-    return $secrets;
+    $code = '';
+    foreach ($secrets as $name => $value) {
+        $escaped = "'" . addcslashes((string) $value, "'\\") . "'";
+        $code .= ".formr\$secret_{$name} = {$escaped}\n";
+    }
+
+    return $code;
 }
 
 /**
@@ -1294,31 +1304,25 @@ function opencpu_extract_secrets($r_code)
  * Only redacts values at least 6 characters long to avoid false positives
  * on short strings that may appear commonly in output.
  *
- * When $custom_r is provided (e.g. from a Run context without a live
- * RunSession), secrets are extracted from that source directly. Otherwise
- * they are loaded from the currently active run session.
- *
  * @param string $text Text to redact secrets from
- * @param string|null $custom_r Optional R source code to extract secrets from
+ * @param array|null $known_secrets Optional pre-loaded secrets array; if null loaded from run
  * @return string Text with secret values replaced
  */
-function opencpu_redact_secrets($text, $custom_r = null)
+function opencpu_redact_secrets($text, $known_secrets = null)
 {
-    if ($custom_r !== null) {
-        $secret_values = array_values(opencpu_extract_secrets($custom_r));
-    } else {
-        $custom_r = opencpu_custom_r();
-        $secret_values = $custom_r ? array_values(opencpu_extract_secrets($custom_r)) : [];
+    if ($known_secrets === null) {
+        $known_secrets = opencpu_secrets();
     }
 
-    if (empty($secret_values)) {
+    $values = array_values($known_secrets);
+    if (empty($values)) {
         return $text;
     }
 
     $to_redact = [];
-    foreach ($secret_values as $v) {
+    foreach ($values as $v) {
         $v = (string) $v;
-        if (strlen($v) >= 6) {
+        if ($v !== '') {
             $to_redact[] = $v;
         }
     }
@@ -1328,27 +1332,6 @@ function opencpu_redact_secrets($text, $custom_r = null)
     }
 
     return str_replace($to_redact, '[SECRET REDACTED]', $text);
-}
-
-/**
- * Decode common R escape sequences in a string literal.
- *
- * Handles: \\, \", \', \n, \t, \r
- *
- * @param string $str Raw string content between R quotes
- * @return string Unescaped string
- */
-function r_unescape($str)
-{
-    $replacements = [
-        '\\\\' => '\\',
-        '\\"' => '"',
-        "\\'" => "'",
-        '\\n' => "\n",
-        '\\t' => "\t",
-        '\\r' => "\r",
-    ];
-    return strtr($str, $replacements);
 }
 
 /**
@@ -1376,10 +1359,12 @@ function opencpu_evaluate($code, $variables = null, $return_format = 'json', $co
         $custom_r = 'eval(parse(text = ' . json_encode($custom_r) . '))' . "\n";
     }
 
+    $r_secrets = opencpu_inject_secrets();
+
     $params = ['x' => '{ 
 (function() {
 	' . $custom_r . '	library(formr)
-	' . $r_variables . '
+	' . $r_secrets . '	' . $r_variables . '
 	' . $code . '
 })() }'];
 
@@ -1473,10 +1458,11 @@ function opencpu_knit_plaintext($source, $variables = null, $return_session = fa
     }
 
     $custom_r = opencpu_custom_r();
+    $r_secrets = opencpu_inject_secrets();
 
     $source = '```{r settings,warning=' . $show_warnings . ',message=' . $show_warnings . ',error=' . $show_errors . ',echo=F}
 library(knitr); library(formr)
-' . ($custom_r ? $custom_r . "\n" : '') . '
+' . ($custom_r ? $custom_r . "\n" : '') . '' . $r_secrets . '
 opts_chunk$set(warning=' . $show_warnings . ',message=' . $show_warnings . ',error=' . $show_errors . ',echo=F,fig.height=7,fig.width=10)
 opts_knit$set(base.url="' . OpenCPU::TEMP_BASE_URL . '")
 ' . $variables . '
@@ -1579,6 +1565,7 @@ function opencpu_knit_iframe($source, $variables = null, $return_session = false
     }
 
     $custom_r = opencpu_custom_r();
+    $r_secrets = opencpu_inject_secrets();
 
     // include=FALSE on the settings chunk: the chunk's R code still runs
     // (library() / opts_chunk$set() / variable assignments), but the chunk
@@ -1593,7 +1580,7 @@ function opencpu_knit_iframe($source, $variables = null, $return_session = false
     $source = $yaml .
         '```{r settings,include=FALSE}
 library(knitr); library(formr)
-' . ($custom_r ? $custom_r . "\n" : '') . '
+' . ($custom_r ? $custom_r . "\n" : '') . '' . $r_secrets . '
 opts_chunk$set(warning=' . $show_warnings . ',message=' . $show_warnings . ',error=' . $show_errors . ',echo=' . $show_warnings . ',fig.height=7,fig.width=10)
 ' . $variables . '
 ```
@@ -1650,10 +1637,11 @@ function opencpu_knitdisplay($source, $variables = null, $return_session = false
     }
 
     $custom_r = opencpu_custom_r();
+    $r_secrets = opencpu_inject_secrets();
 
     $source = '```{r settings,warning=' . $show_warnings . ',message=' . $show_warnings . ',error=' . $show_errors . ',echo=F}
 library(knitr); library(formr)
-' . ($custom_r ? $custom_r . "\n" : '') . '
+' . ($custom_r ? $custom_r . "\n" : '') . '' . $r_secrets . '
 opts_chunk$set(warning=' . $show_warnings . ',message=' . $show_warnings . ',error=' . $show_errors . ',echo=F,fig.height=7,fig.width=10)
 opts_knit$set(base.url="' . OpenCPU::TEMP_BASE_URL . '")
 ' . $variables . '
@@ -1687,10 +1675,11 @@ function opencpu_knitadmin($source, $variables = null, $return_session = false)
     }
 
     $custom_r = opencpu_custom_r();
+    $r_secrets = opencpu_inject_secrets();
 
     $source = '```{r settings,warning=' . $show_warnings . ',message=' . $show_warnings . ',error=' . $show_errors . ',echo=F}
 library(knitr); library(formr)
-' . ($custom_r ? $custom_r . "\n" : '') . '
+' . ($custom_r ? $custom_r . "\n" : '') . '' . $r_secrets . '
 opts_chunk$set(warning=' . $show_warnings . ',message=' . $show_warnings . ',error=' . $show_errors . ',echo=F)
 opts_knit$set(base.url="' . OpenCPU::TEMP_BASE_URL . '")
 ' . $variables . '
@@ -1723,10 +1712,11 @@ function opencpu_knit_email($source, array $variables = null, $return_format = '
     }
 
     $custom_r = opencpu_custom_r();
+    $r_secrets = opencpu_inject_secrets();
 
     $source = '```{r settings,warning=' . $show_warnings . ',message=' . $show_warnings . ',error=' . $show_errors . ',echo=F}
 library(knitr); library(formr)
-' . ($custom_r ? $custom_r . "\n" : '') . '
+' . ($custom_r ? $custom_r . "\n" : '') . '' . $r_secrets . '
 opts_chunk$set(warning=' . $show_warnings . ',message=' . $show_warnings . ',error=' . $show_errors . ',echo=F,fig.retina=2)
 opts_knit$set(upload.fun=function(x) { paste0("cid:", URLencode(basename(x))) })
 ' . $variables . '
@@ -1788,12 +1778,12 @@ function opencpu_multistring_parse(UnitSession $unitSession, array $string_templ
 }
 
 /**
- * Substitute parsed strings in the collection of items that were sent for parsing
- * This function does not return anything as the collection of items is passed by reference
- * For objects having the property 'label_parsed', they are checked and substituted
+ * Redact known secret values from a given text. Replaces all occurrences
+ * of secret values with the placeholder.
  *
- * @param array $array An array of data contaning label templates
- * @param array $parsed_strings An array of parsed labels
+ * @param string $text Text to redact secrets from
+ * @param array|null $known_secrets Optional pre-loaded secrets array; if null loaded from run
+ * @return string Text with secret values replaced
  */
 function opencpu_substitute_parsed_strings(array &$array, array $parsed_strings)
 {
@@ -1960,7 +1950,7 @@ function opencpu_last_error()
 {
     global $opencpu_session;
     if ($opencpu_session !== null) {
-        return $opencpu_session->getError();
+        return opencpu_redact_secrets($opencpu_session->getError());
     }
     return null;
 }

--- a/application/Functions.php
+++ b/application/Functions.php
@@ -66,9 +66,9 @@ function notify_user_error($error, $public_message = '')
     // that drives $show_errors='TRUE' in the OpenCPU knit chunks.
     if (!$run_session || $run_session->isCron() || $run_session->isTesting()) {
         if ($error instanceof Exception) {
-            $message .= $error->getMessage();
+            $message .= opencpu_redact_secrets($error->getMessage());
         } else {
-            $message .= $error;
+            $message .= opencpu_redact_secrets($error);
         }
     }
     alert($message, 'alert-danger');
@@ -1250,6 +1250,108 @@ function opencpu_custom_r()
 }
 
 /**
+ * Parse custom R code for secret variable definitions.
+ * Matches assignment patterns like secret_<name> <- "value" or secret_<name> = 'value'.
+ * Only captures string literals (not expressions or function calls).
+ *
+ * @param string $r_code The R source code to scan
+ * @return array Associative array of [var_name => raw_value]
+ */
+function opencpu_extract_secrets($r_code)
+{
+    $secrets = [];
+    if (empty($r_code)) {
+        return $secrets;
+    }
+
+    preg_match_all(
+        '/^[ \t]*secret_([a-zA-Z_][a-zA-Z0-9_.]*)\s*(?:<-|=)\s*"((?:[^"\\\\]|\\\\.)*)"\s*(?:#.*)?$/m',
+        $r_code,
+        $matches,
+        PREG_SET_ORDER
+    );
+    foreach ($matches as $m) {
+        $secrets['secret_' . $m[1]] = r_unescape($m[2]);
+    }
+
+    preg_match_all(
+        "/^[ \t]*secret_([a-zA-Z_][a-zA-Z0-9_.]*)\s*(?:<-|=)\s*'((?:[^'\\\\]|\\\\.)*)'\s*(?:#.*)?$/m",
+        $r_code,
+        $matches,
+        PREG_SET_ORDER
+    );
+    foreach ($matches as $m) {
+        $secrets['secret_' . $m[1]] = r_unescape($m[2]);
+    }
+
+    return $secrets;
+}
+
+/**
+ * Redact known secret values from a string.
+ *
+ * Replaces every occurrence of each secret value with "[SECRET REDACTED]".
+ * Only redacts values at least 6 characters long to avoid false positives
+ * on short strings that may appear commonly in output.
+ *
+ * When $custom_r is provided (e.g. from a Run context without a live
+ * RunSession), secrets are extracted from that source directly. Otherwise
+ * they are loaded from the currently active run session.
+ *
+ * @param string $text Text to redact secrets from
+ * @param string|null $custom_r Optional R source code to extract secrets from
+ * @return string Text with secret values replaced
+ */
+function opencpu_redact_secrets($text, $custom_r = null)
+{
+    if ($custom_r !== null) {
+        $secret_values = array_values(opencpu_extract_secrets($custom_r));
+    } else {
+        $custom_r = opencpu_custom_r();
+        $secret_values = $custom_r ? array_values(opencpu_extract_secrets($custom_r)) : [];
+    }
+
+    if (empty($secret_values)) {
+        return $text;
+    }
+
+    $to_redact = [];
+    foreach ($secret_values as $v) {
+        $v = (string) $v;
+        if (strlen($v) >= 6) {
+            $to_redact[] = $v;
+        }
+    }
+
+    if (empty($to_redact)) {
+        return $text;
+    }
+
+    return str_replace($to_redact, '[SECRET REDACTED]', $text);
+}
+
+/**
+ * Decode common R escape sequences in a string literal.
+ *
+ * Handles: \\, \", \', \n, \t, \r
+ *
+ * @param string $str Raw string content between R quotes
+ * @return string Unescaped string
+ */
+function r_unescape($str)
+{
+    $replacements = [
+        '\\\\' => '\\',
+        '\\"' => '"',
+        "\\'" => "'",
+        '\\n' => "\n",
+        '\\t' => "\t",
+        '\\r' => "\r",
+    ];
+    return strtr($str, $replacements);
+}
+
+/**
  * Execute a piece of code against OpenCPU
  *
  * @param string $code Each code line should be separated by a newline characted
@@ -1739,7 +1841,7 @@ function opencpu_debug($session, OpenCPU $ocpu = null, $rtype = 'json')
         $debug['Response'] = 'No OpenCPU_Session found. Server may be down.';
         if ($ocpu !== null) {
             $request = $ocpu->getRequest();
-            $debug['Request'] = (string) $request;
+            $debug['Request'] = opencpu_redact_secrets((string) $request);
             $reponse_info = $ocpu->getRequestInfo();
             $debug['Request Headers'] = pre_htmlescape(print_r($reponse_info['request_header'], 1));
         }
@@ -1751,14 +1853,14 @@ function opencpu_debug($session, OpenCPU $ocpu = null, $rtype = 'json')
             if (isset($params['text'])) {
                 $debug['R Markdown'] = '
 					<a href="#" class="download_r_code" data-filename="formr_rmarkdown.Rmd">Download R Markdown file to debug.</a><br>
-					<textarea class="form-control" rows="10" readonly>' . h(stripslashes(substr($params['text'], 1, -1))) . '</textarea>';
+					<textarea class="form-control" rows="10" readonly>' . h(opencpu_redact_secrets(stripslashes(substr($params['text'], 1, -1)))) . '</textarea>';
             } elseif (isset($params['x'])) {
                 $debug['R Code'] = '
 					<a href="#" class="download_r_code" data-filename="formr_values_showifs.R">Download R code file to debug.</a><br>
-					<textarea class="form-control" rows="10" readonly>' . h((substr($params['x'], 1, -1))) . '</textarea>';
+					<textarea class="form-control" rows="10" readonly>' . h(opencpu_redact_secrets(substr($params['x'], 1, -1))) . '</textarea>';
             }
             if ($session->hasError()) {
-                $debug['Response'] = pre_htmlescape($session->getError());
+                $debug['Response'] = pre_htmlescape(opencpu_redact_secrets($session->getError()));
             } else {
                 if (($files = $session->getFiles("knit.html"))) {
                     $iframesrc = $files['knit.html'];
@@ -1767,9 +1869,9 @@ function opencpu_debug($session, OpenCPU $ocpu = null, $rtype = 'json')
 						<a href="' . $iframesrc . '" target="_blank">Open in new window</a>
 					</p>';
                 } else if (isset($params['text']) || $rtype === 'text') {
-                    $debug['Response'] = stringBool($session->getObject('text'));
+                    $debug['Response'] = opencpu_redact_secrets(stringBool($session->getObject('text')));
                 } else {
-                    $debug['Response'] = pre_htmlescape(json_encode($session->getJSONObject(), JSON_PRETTY_PRINT + JSON_UNESCAPED_UNICODE));
+                    $debug['Response'] = pre_htmlescape(opencpu_redact_secrets(json_encode($session->getJSONObject(), JSON_PRETTY_PRINT + JSON_UNESCAPED_UNICODE)));
                 }
             }
 
@@ -1782,10 +1884,10 @@ function opencpu_debug($session, OpenCPU $ocpu = null, $rtype = 'json')
                 }
                 $debug['Locations'] = $locations;
             }
-            $debug['Session Info'] = pre_htmlescape($session->getInfo());
-            $debug['Session Console'] = pre_htmlescape($session->getConsole());
-            $debug['Session Stdout'] = pre_htmlescape($session->getStdout());
-            $debug['Request'] = pre_htmlescape((string) $request);
+            $debug['Session Info'] = pre_htmlescape(opencpu_redact_secrets($session->getInfo()));
+            $debug['Session Console'] = pre_htmlescape(opencpu_redact_secrets($session->getConsole()));
+            $debug['Session Stdout'] = pre_htmlescape(opencpu_redact_secrets($session->getStdout()));
+            $debug['Request'] = pre_htmlescape(opencpu_redact_secrets((string) $request));
 
             $reponse_headers = $session->getResponseHeaders();
             $debug['Response Headers'] = pre_htmlescape(print_r($reponse_headers, 1));
@@ -1808,7 +1910,7 @@ function opencpu_log($msg)
     } else {
         $log .= $msg;
     }
-    error_log($log . "\n", 3, get_log_file('opencpu.log'));
+    error_log(opencpu_redact_secrets($log) . "\n", 3, get_log_file('opencpu.log'));
 }
 
 function opencpu_formr_variables($q)

--- a/application/Functions.php
+++ b/application/Functions.php
@@ -1362,6 +1362,35 @@ function opencpu_redact_secrets($text, $known_secrets = null)
 }
 
 /**
+ * Check whether R code is syntactically valid by calling base::parse() on OpenCPU.
+ *
+ * Runs R's built-in parser (which only checks syntax, not semantics).
+ * The code is NOT executed — parse() returns an expression object.
+ *
+ * @param string $code The R code to validate
+ * @return array{valid: bool|null, message: string}
+ *               valid=true  → syntax is valid
+ *               valid=false → syntax error, message contains the R error
+ *               valid=null  → OpenCPU unreachable, message explains
+ */
+function opencpu_validate_r_code(string $code): array {
+    if (trim($code) === '') {
+        return ['valid' => true, 'message' => ''];
+    }
+    try {
+        $session = OpenCPU::getInstance()->post('/base/R/parse', ['text' => json_encode($code)]);
+        if ($session->hasError()) {
+            $msg = $session->getError();
+            $msg = preg_replace('/^R Error: /', '', $msg);
+            return ['valid' => false, 'message' => $msg];
+        }
+        return ['valid' => true, 'message' => ''];
+    } catch (OpenCPU_Exception $e) {
+        return ['valid' => null, 'message' => 'Could not contact OpenCPU server to validate R code.'];
+    }
+}
+
+/**
  * Execute a piece of code against OpenCPU
  *
  * @param string $code Each code line should be separated by a newline characted

--- a/application/Functions.php
+++ b/application/Functions.php
@@ -1239,14 +1239,23 @@ function opencpu_prepare_api_access($code, &$variables)
  */
 function opencpu_custom_r()
 {
-    $run_session = Site::getInstance()->getRunSession();
+    $run_session = run_session();
+    if (!$run_session) {
+        $run_session = Site::getInstance()->getRunSession();
+    }
+
+    $run = null;
     if ($run_session) {
         $run = $run_session->getRun();
-        if ($run) {
-            return $run->getCustomRFunctions();
-        }
     }
-    return '';
+    if (!$run) {
+        $run = Site::getInstance()->getRun();
+    }
+    if (!$run) {
+        return '';
+    }
+
+    return $run->getCustomRFunctions();
 }
 
 /**
@@ -1257,28 +1266,43 @@ function opencpu_custom_r()
  */
 function opencpu_secrets()
 {
-    $run_session = Site::getInstance()->getRunSession();
-    if ($run_session) {
-        $run = $run_session->getRun();
-        if ($run) {
-            return $run->getSecrets();
-        }
+    $run_session = run_session();
+    if (!$run_session) {
+        $run_session = Site::getInstance()->getRunSession();
     }
 
-    return [];
+    $run = null;
+    if ($run_session) {
+        $run = $run_session->getRun();
+    }
+    if (!$run) {
+        $run = Site::getInstance()->getRun();
+    }
+    if (!$run) {
+        return [];
+    }
+
+    return $run->getSecrets();
 }
 
 /**
  * Generate R code to inject secrets as .formr$ variables.
  *
+ * Only injects secrets whose `.formr$secret_<name>` reference appears in
+ * the R code, matching the conditional-injection pattern used by data
+ * variables and API tokens. Secrets referenced via string construction
+ * (e.g. `paste0(".formr$secret_", var)`) are not detected — use the
+ * literal `.formr$secret_<name>` form.
+ *
  * Secrets are assigned to the hidden .formr$ environment so they are
  * accessible in R as .formr$secret_<name> but do not appear in ls()
  * output or pollute the global scope.
  *
- * @param array|null $secrets Optional secrets array; if null loaded from run
- * @return string R code assigning each secret
+ * @param string $q The R code or R Markdown source to scan for secret references.
+ * @param array|null $secrets Optional secrets array; if null loaded from run.
+ * @return string R code assigning each referenced secret.
  */
-function opencpu_inject_secrets($secrets = null)
+function opencpu_inject_secrets($q, $secrets = null)
 {
     if ($secrets === null) {
         $secrets = opencpu_secrets();
@@ -1290,6 +1314,9 @@ function opencpu_inject_secrets($secrets = null)
 
     $code = '';
     foreach ($secrets as $name => $value) {
+        if (strpos((string) $q, ".formr\$secret_{$name}") === false) {
+            continue;
+        }
         $escaped = "'" . addcslashes((string) $value, "'\\") . "'";
         $code .= ".formr\$secret_{$name} = {$escaped}\n";
     }
@@ -1359,7 +1386,7 @@ function opencpu_evaluate($code, $variables = null, $return_format = 'json', $co
         $custom_r = 'eval(parse(text = ' . json_encode($custom_r) . '))' . "\n";
     }
 
-    $r_secrets = opencpu_inject_secrets();
+    $r_secrets = opencpu_inject_secrets($code);
 
     $params = ['x' => '{ 
 (function() {
@@ -1458,7 +1485,7 @@ function opencpu_knit_plaintext($source, $variables = null, $return_session = fa
     }
 
     $custom_r = opencpu_custom_r();
-    $r_secrets = opencpu_inject_secrets();
+    $r_secrets = opencpu_inject_secrets($source);
 
     $source = '```{r settings,warning=' . $show_warnings . ',message=' . $show_warnings . ',error=' . $show_errors . ',echo=F}
 library(knitr); library(formr)
@@ -1556,6 +1583,12 @@ function opencpu_knit_iframe($source, $variables = null, $return_session = false
         $show_warnings = 'TRUE';
     }
 
+    // Save the original source so we can scan it for secret references
+    // before YAML extraction removes the frontmatter. Secret references in
+    // YAML are not a realistic concern (YAML is markdown metadata, not R
+    // code), but scanning the full original text is more defensive.
+    $source_with_yaml = $source;
+
     $yaml = "";
     $yaml_lines = '/^\-\-\-/um';
     if (preg_match_all($yaml_lines, (string)$source) >= 2) {
@@ -1565,7 +1598,7 @@ function opencpu_knit_iframe($source, $variables = null, $return_session = false
     }
 
     $custom_r = opencpu_custom_r();
-    $r_secrets = opencpu_inject_secrets();
+    $r_secrets = opencpu_inject_secrets($source_with_yaml);
 
     // include=FALSE on the settings chunk: the chunk's R code still runs
     // (library() / opts_chunk$set() / variable assignments), but the chunk
@@ -1637,7 +1670,7 @@ function opencpu_knitdisplay($source, $variables = null, $return_session = false
     }
 
     $custom_r = opencpu_custom_r();
-    $r_secrets = opencpu_inject_secrets();
+    $r_secrets = opencpu_inject_secrets($source);
 
     $source = '```{r settings,warning=' . $show_warnings . ',message=' . $show_warnings . ',error=' . $show_errors . ',echo=F}
 library(knitr); library(formr)
@@ -1675,7 +1708,7 @@ function opencpu_knitadmin($source, $variables = null, $return_session = false)
     }
 
     $custom_r = opencpu_custom_r();
-    $r_secrets = opencpu_inject_secrets();
+    $r_secrets = opencpu_inject_secrets($source);
 
     $source = '```{r settings,warning=' . $show_warnings . ',message=' . $show_warnings . ',error=' . $show_errors . ',echo=F}
 library(knitr); library(formr)
@@ -1712,7 +1745,7 @@ function opencpu_knit_email($source, array $variables = null, $return_format = '
     }
 
     $custom_r = opencpu_custom_r();
-    $r_secrets = opencpu_inject_secrets();
+    $r_secrets = opencpu_inject_secrets($source);
 
     $source = '```{r settings,warning=' . $show_warnings . ',message=' . $show_warnings . ',error=' . $show_errors . ',echo=F}
 library(knitr); library(formr)

--- a/application/Functions.php
+++ b/application/Functions.php
@@ -1272,9 +1272,9 @@ function opencpu_evaluate($code, $variables = null, $return_format = 'json', $co
     $custom_r = opencpu_custom_r();
 
     $params = ['x' => '{ 
+' . ($custom_r ? $custom_r . "\n\n" : '') . '
 (function() {
 	library(formr)
-	' . ($custom_r ? $custom_r . "\n" : '') . '
 	' . $r_variables . '
 	' . $code . '
 })() }'];

--- a/application/Functions.php
+++ b/application/Functions.php
@@ -1270,11 +1270,13 @@ function opencpu_evaluate($code, $variables = null, $return_format = 'json', $co
     $r_variables = is_string($variables) ? $variables : opencpu_define_vars($variables, $context);
 
     $custom_r = opencpu_custom_r();
+    if ($custom_r) {
+        $custom_r = 'eval(parse(text = ' . json_encode($custom_r) . '))' . "\n";
+    }
 
     $params = ['x' => '{ 
-' . ($custom_r ? $custom_r . "\n\n" : '') . '
 (function() {
-	library(formr)
+	' . $custom_r . '	library(formr)
 	' . $r_variables . '
 	' . $code . '
 })() }'];

--- a/application/Model/Run.php
+++ b/application/Model/Run.php
@@ -792,6 +792,9 @@ class Run extends Model
     private $custom_r_cache = null;
     private $custom_r_loaded = false;
 
+    private $secrets_cache = null;
+    private $secrets_loaded = false;
+
     public function getCustomRFunctions()
     {
         if ($this->custom_r_loaded) {
@@ -802,6 +805,18 @@ class Run extends Model
             $this->custom_r_cache = $this->getFileContent($this->custom_r_path);
         }
         return $this->custom_r_cache;
+    }
+
+    public function getSecrets()
+    {
+        if ($this->secrets_loaded) {
+            return $this->secrets_cache;
+        }
+        $this->secrets_loaded = true;
+        if ($this->id) {
+            $this->secrets_cache = RunSecret::getSecretsForRun($this->id);
+        }
+        return $this->secrets_cache ?: array();
     }
 
     public function getManifestJSON()
@@ -916,6 +931,24 @@ class Run extends Model
             $posted['expire_cookie'] = $this->expire_cookie;
         }
         unset($posted['expire_cookie_value'], $posted['expire_cookie_unit']);
+
+        // Handle secrets before the main loop so they don't hit "Invalid setting"
+        if (isset($posted['secrets_json'])) {
+            $secrets = json_decode($posted['secrets_json'], true);
+            if (is_array($secrets)) {
+                RunSecret::setSecretsForRun($this->id, $secrets);
+            }
+            unset($posted['secrets_json']);
+        }
+
+        // The export bundle includes 'secrets' as an indexed array of key names
+        // (no values — they're encrypted per-run and cannot be transferred).
+        // Create placeholder entries so the admin sees which secrets need to
+        // be reconfigured after import.
+        if (isset($posted['secrets']) && is_array($posted['secrets'])) {
+            RunSecret::ensureSecretsExist($this->id, $posted['secrets']);
+            unset($posted['secrets']);
+        }
 
         $updates = array();
         foreach ($posted as $name => $value) {
@@ -1225,7 +1258,8 @@ class Run extends Model
             'cron_active' => (int) $this->cron_active,
             'custom_js' => $this->getCustomJS(),
             'custom_css' => $this->getCustomCSS(),
-            'custom_r' => opencpu_redact_secrets($this->getCustomRFunctions(), $this->getCustomRFunctions()),
+            'custom_r' => $this->getCustomRFunctions(),
+            'secrets' => array_keys($this->getSecrets()),
             'expiresOn' => $this->expiresOn,
         );
 

--- a/application/Model/Run.php
+++ b/application/Model/Run.php
@@ -1225,7 +1225,7 @@ class Run extends Model
             'cron_active' => (int) $this->cron_active,
             'custom_js' => $this->getCustomJS(),
             'custom_css' => $this->getCustomCSS(),
-            'custom_r' => $this->getCustomRFunctions(),
+            'custom_r' => opencpu_redact_secrets($this->getCustomRFunctions(), $this->getCustomRFunctions()),
             'expiresOn' => $this->expiresOn,
         );
 

--- a/application/Model/Run.php
+++ b/application/Model/Run.php
@@ -44,6 +44,7 @@ class Run extends Model
     public $messages = array();
     public $custom_css_path = null;
     public $custom_js_path = null;
+    public $custom_r_path = null;
     public $manifest_json_path = null;
     public $header_image_path = null;
     public $title = null;
@@ -83,6 +84,7 @@ class Run extends Model
         "tos",
         "custom_css",
         "custom_js",
+        "custom_r",
         "manifest_json",
         "cron_active",
         "osf_project_id",
@@ -135,7 +137,7 @@ class Run extends Model
             return;
         }
 
-        $columns = "id, user_id, created, modified, name, api_secret_hash, public, cron_active, cron_fork, locked, header_image_path, title, description, description_parsed, footer_text, footer_text_parsed, public_blurb, public_blurb_parsed, privacy, privacy_parsed, tos, tos_parsed, custom_css_path, custom_js_path, manifest_json_path, osf_project_id, use_material_design, expire_cookie, expiresOn, vapid_public_key, vapid_private_key, pwa_icon_path";
+        $columns = "id, user_id, created, modified, name, api_secret_hash, public, cron_active, cron_fork, locked, header_image_path, title, description, description_parsed, footer_text, footer_text_parsed, public_blurb, public_blurb_parsed, privacy, privacy_parsed, tos, tos_parsed, custom_css_path, custom_js_path, custom_r_path, manifest_json_path, osf_project_id, use_material_design, expire_cookie, expiresOn, vapid_public_key, vapid_private_key, pwa_icon_path";
         $where = $this->id ? array('id' => $this->id) : array('name' => $this->name);
         $vars = $this->db->findRow('survey_runs', $where, $columns);
 
@@ -787,6 +789,21 @@ class Run extends Model
         return "";
     }
 
+    private $custom_r_cache = null;
+    private $custom_r_loaded = false;
+
+    public function getCustomRFunctions()
+    {
+        if ($this->custom_r_loaded) {
+            return $this->custom_r_cache;
+        }
+        $this->custom_r_loaded = true;
+        if ($this->custom_r_path != null) {
+            $this->custom_r_cache = $this->getFileContent($this->custom_r_path);
+        }
+        return $this->custom_r_cache;
+    }
+
     public function getManifestJSON()
     {
         if ($this->manifest_json_path != null) {
@@ -911,13 +928,16 @@ class Run extends Model
                 continue;
             }
 
-            if ($name == "custom_js" || $name == "custom_css" || $name == "manifest_json") {
+            if ($name == "custom_js" || $name == "custom_css" || $name == "custom_r" || $name == "manifest_json") {
                 if ($name == "custom_js") {
                     $asset_path = $this->custom_js_path;
                     $file_ending = '.js';
                 } elseif ($name == "custom_css") {
                     $asset_path = $this->custom_css_path;
                     $file_ending = '.css';
+                } elseif ($name == "custom_r") {
+                    $asset_path = $this->custom_r_path;
+                    $file_ending = '.R';
                 } elseif ($name == "manifest_json") {
                     $asset_path = $this->manifest_json_path;
                     $file_ending = '.json';
@@ -1205,6 +1225,7 @@ class Run extends Model
             'cron_active' => (int) $this->cron_active,
             'custom_js' => $this->getCustomJS(),
             'custom_css' => $this->getCustomCSS(),
+            'custom_r' => $this->getCustomRFunctions(),
             'expiresOn' => $this->expiresOn,
         );
 

--- a/application/Model/RunSecret.php
+++ b/application/Model/RunSecret.php
@@ -1,0 +1,113 @@
+<?php
+
+class RunSecret extends Model
+{
+    public $id = null;
+    public $run_id = null;
+    public $name = null;
+    public $value_encrypted = null;
+    public $created = null;
+    public $modified = null;
+
+    protected $table = 'survey_run_secrets';
+
+    public static function getSecretsForRun($run_id)
+    {
+        $db = DB::getInstance();
+        $rows = $db->select(array('name', 'value_encrypted'))
+            ->from('survey_run_secrets')
+            ->where(array('run_id' => $run_id))
+            ->statement()
+            ->fetchAll(PDO::FETCH_ASSOC);
+
+        $secrets = array();
+        foreach ($rows as $row) {
+            $decrypted = Crypto::decrypt($row['value_encrypted']);
+            if ($decrypted !== null) {
+                $secrets[$row['name']] = $decrypted;
+            }
+        }
+
+        return $secrets;
+    }
+
+    public static function setSecretsForRun($run_id, array $secrets)
+    {
+        $db = DB::getInstance();
+        $now = mysql_now();
+
+        $existing = $db->select(array('name'))
+            ->from('survey_run_secrets')
+            ->where(array('run_id' => $run_id))
+            ->statement()
+            ->fetchAll(PDO::FETCH_COLUMN, 0);
+
+        $seen = array();
+
+        foreach ($secrets as $name => $value) {
+            $name = trim($name);
+            if ($name === '' || $value === '') {
+                continue;
+            }
+
+            $encrypted = Crypto::encrypt($value);
+            if ($encrypted === null) {
+                continue;
+            }
+
+            $seen[] = $name;
+
+            if (in_array($name, $existing)) {
+                $db->update('survey_run_secrets', array(
+                    'value_encrypted' => $encrypted,
+                    'modified' => $now,
+                ), array('run_id' => $run_id, 'name' => $name));
+            } else {
+                $db->insert('survey_run_secrets', array(
+                    'run_id' => $run_id,
+                    'name' => $name,
+                    'value_encrypted' => $encrypted,
+                    'created' => $now,
+                    'modified' => $now,
+                ));
+            }
+        }
+
+        $to_delete = array_diff($existing, $seen);
+        foreach ($to_delete as $name) {
+            $db->delete('survey_run_secrets', array('run_id' => $run_id, 'name' => $name));
+        }
+    }
+
+    public static function ensureSecretsExist($run_id, array $names)
+    {
+        $db = DB::getInstance();
+        $now = mysql_now();
+
+        $existing = $db->select(array('name'))
+            ->from('survey_run_secrets')
+            ->where(array('run_id' => $run_id))
+            ->statement()
+            ->fetchAll(PDO::FETCH_COLUMN, 0);
+
+        foreach ($names as $name) {
+            $name = trim($name);
+            if ($name === '') {
+                continue;
+            }
+
+            if (!in_array($name, $existing)) {
+                $encrypted = Crypto::encrypt('');
+                if ($encrypted !== null) {
+                    $db->insert('survey_run_secrets', array(
+                        'run_id' => $run_id,
+                        'name' => $name,
+                        'value_encrypted' => $encrypted,
+                        'created' => $now,
+                        'modified' => $now,
+                    ));
+                }
+            }
+        }
+    }
+}

--- a/application/Model/RunUnit/RunUnit.php
+++ b/application/Model/RunUnit/RunUnit.php
@@ -542,11 +542,11 @@ OVERVIEW_BODY
             alert('OpenCPU is probably down or inaccessible. Please retry in a few minutes.', 'alert-danger');
             return false;
         } elseif ($ocpu->hasError()) {
-            $this->errors['log'] = $this->getLogMessage('error_opencpu_r', 'OpenCPU R error. Fix code.' . $ocpu->getError());
+            $this->errors['log'] = $this->getLogMessage('error_opencpu_r', 'OpenCPU R error. Fix code.' . opencpu_redact_secrets($ocpu->getError()));
             notify_user_error(opencpu_debug($ocpu), 'There was a computational error.');
 
             // notify study admin about OpenCPU R error in rendering
-            $message = 'OpenCPU R error during rendering in ' . $this->type . ' at position ' . $this->position . ': ' . $ocpu->getError();
+            $message = 'OpenCPU R error during rendering in ' . $this->type . ' at position ' . $this->position . ': ' . opencpu_redact_secrets($ocpu->getError());
             notify_study_admin($unitSession, $message, 'error');
             return false;
         } elseif ($admin) {

--- a/application/Model/UnitSession.php
+++ b/application/Model/UnitSession.php
@@ -316,6 +316,9 @@ class UnitSession extends Model {
         // and "orphaned mid-flow". See "Hygiene 4" in EXPIRY_PLAN.md.
         // Track A: also set state='ENDED' (dual-write) and state_log
         // (structured sibling of the human-readable result_log).
+        if ($this->result_log !== null && mb_strlen($this->result_log, '8bit') > 60000) {
+            $this->result_log = mb_strcut($this->result_log, 0, 60000);
+        }
         $ended = $this->db->exec(
                 "UPDATE `survey_unit_sessions` SET
                 `ended` = NOW(),
@@ -365,6 +368,9 @@ class UnitSession extends Model {
      * See REFACTOR_QUEUE_PLAN.md A6 / D5.
      */
     public function logResult() {
+        if ($this->result_log !== null && mb_strlen($this->result_log, '8bit') > 60000) {
+            $this->result_log = mb_strcut($this->result_log, 0, 60000);
+        }
         $log = $this->db->exec(
                 "UPDATE `survey_unit_sessions` SET
                 `result` = :result,

--- a/application/Queue/EmailQueue.php
+++ b/application/Queue/EmailQueue.php
@@ -164,6 +164,10 @@ class EmailQueue extends Queue {
             ['id' => $email_id, 'status_code' => $status_code]
         );
         
+        if ($result_log !== null && mb_strlen($result_log, '8bit') > 60000) {
+            $result_log = mb_strcut($result_log, 0, 60000);
+        }
+
         if($session_id) {
             $this->db->exec(
                 'UPDATE `survey_unit_sessions` SET `result` = :result, `result_log` = :resultlog WHERE `id` = :session_id',

--- a/sql/patches/057_custom_r_path.sql
+++ b/sql/patches/057_custom_r_path.sql
@@ -1,0 +1,8 @@
+-- Add column for run-specific R functions file path, analogous to
+-- custom_css_path / custom_js_path. R functions defined here are
+-- injected into every OpenCPU evaluation and knitr rendering call
+-- for this run, making them available in showif, value, feedback,
+-- relative_to, branch conditions, external URLs, email body, etc.
+
+ALTER TABLE `survey_runs`
+    ADD COLUMN `custom_r_path` varchar(255) COLLATE utf8mb4_unicode_ci DEFAULT NULL AFTER `custom_js_path`;

--- a/sql/patches/058_result_log_mediumtext.sql
+++ b/sql/patches/058_result_log_mediumtext.sql
@@ -1,0 +1,1 @@
+ALTER TABLE `survey_unit_sessions` MODIFY `result_log` MEDIUMTEXT COLLATE utf8mb4_unicode_ci DEFAULT NULL;

--- a/sql/patches/059_create_run_secrets.sql
+++ b/sql/patches/059_create_run_secrets.sql
@@ -1,0 +1,12 @@
+CREATE TABLE `survey_run_secrets` (
+  `id` int(10) unsigned NOT NULL AUTO_INCREMENT,
+  `run_id` int(10) unsigned NOT NULL,
+  `name` varchar(255) NOT NULL COMMENT 'Variable name without secret_ prefix',
+  `value_encrypted` text NOT NULL COMMENT 'Encrypted via Crypto::encrypt()',
+  `created` datetime NOT NULL,
+  `modified` datetime NOT NULL,
+  PRIMARY KEY (`id`),
+  UNIQUE KEY `run_secret_name` (`run_id`, `name`),
+  KEY `run_id` (`run_id`),
+  CONSTRAINT `survey_run_secrets_ibfk_1` FOREIGN KEY (`run_id`) REFERENCES `survey_runs` (`id`) ON DELETE CASCADE ON UPDATE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;

--- a/templates/admin/run/menu.php
+++ b/templates/admin/run/menu.php
@@ -25,7 +25,7 @@
     </div>
     <div class="box-body no-padding">
         <ul class="nav nav-pills nav-stacked">
-            <li><a href="<?php echo admin_run_url($run->name, 'create_new_test_code'); ?>" title="Test run with a new guinea pig account. You'll start from the beginning and have extended debugging ability."><i class="fa fa-stethoscope"></i> Test Run</a></li>
+            <li><a target="_blank" href="<?php echo admin_run_url($run->name, 'create_new_test_code'); ?>" title="Test run with a new guinea pig account. You'll start from the beginning and have extended debugging ability."><i class="fa fa-stethoscope"></i> Test Run</a></li>
 
             <li><a href="<?php echo admin_run_url($run->name, 'user_overview?session=XXX'); ?>" title="See a list of existing guinea pigs/test sessions and continue testing."><i class="fa fa-wheelchair"></i> Old Guinea Pigs</a></li>
 

--- a/templates/admin/run/settings.php
+++ b/templates/admin/run/settings.php
@@ -315,8 +315,10 @@
                                                 <?php foreach ($reminders as $reminder): ?>
                                                     <div class="col-md-6 single_unit_display">
                                                         <form class="form-horizontal edit_run" enctype="multipart/form-data" name="edit_run" method="post" action="<?php echo admin_run_url($run->name); ?>" data-units='<?php echo json_encode($reminder['html_units']); ?>'>
-                                                            <a href="<?= admin_run_url($run->name, 'delete_run_unit?type=Email&special=ReminderEmail&redirect=settings:::reminder&unit_id=' . $reminder['id']) ?>" class="reminder-delete remove_unit_from_run" data-action="<?php echo admin_run_url($run->name); ?>" data-id="<?php echo $reminder['id']; ?>"><i class="fa fa-2x fa-trash"></i></a>
                                                             <div class="run_units"></div>
+                                                            <p class="text-right" style="margin: 10px 0 0;">
+                                                                <a href="<?= admin_run_url($run->name, 'delete_run_unit?type=Email&special=ReminderEmail&redirect=settings:::reminder&unit_id=' . $reminder['id']) ?>" class="btn btn-danger btn-xs remove_unit_from_run" data-action="<?php echo admin_run_url($run->name); ?>" data-id="<?php echo $reminder['id']; ?>"><i class="fa fa-trash"></i> Delete Reminder</a>
+                                                            </p>
                                                         </form>
                                                     </div>
                                                 <?php endforeach; ?>

--- a/templates/admin/run/settings.php
+++ b/templates/admin/run/settings.php
@@ -117,7 +117,7 @@
                                                 <div class="form-group">
                                                     <label for="description">Description</label>
                                                     <p>Will be shown at the top of every page of the study. Optional.</p>
-                                                    <textarea data-editor="markdown" placeholder="Description" name="description" id="description" rows="20" cols="80" class="big_ace_editor form-control"><?= h($run->description); ?></textarea>
+                                                    <textarea data-editor="markdown" placeholder="Description" name="description" id="description" rows="10" cols="80" class="big_ace_editor form-control"><?= h($run->description); ?></textarea>
                                                 </div>
                                             </div>
                                         </div>
@@ -126,7 +126,7 @@
                                                 <div class="form-group">
                                                     <p>Your Imprint should contain information about who is responsible for the study, and how they can be contacted. It should also link to your privacy policy and in some cases to the settings page, where users can unsubscribe from emails and log out.</p>
                                                     <label title="Will be shown on every page of the run, good for contact info" for="footer_text">Imprint/Footer text</label>
-                                                    <textarea data-editor="markdown" placeholder="Footer text" name="footer_text" id="footer_text" rows="20" cols="80" class="big_ace_editor form-control"><?= h($run->footer_text); ?></textarea>
+                                                    <textarea data-editor="markdown" placeholder="Footer text" name="footer_text" id="footer_text" rows="10" cols="80" class="big_ace_editor form-control"><?= h($run->footer_text); ?></textarea>
                                                 </div>
                                             </div>
                                         </div>
@@ -135,7 +135,7 @@
                                                 <div class="form-group">
                                                     <label title="This will be the description of your study shown on the public page" for="public_blurb">Public blurb</label>
                                                     <p>This will be the description of your study shown on the <a href="<?php echo site_url("/public/studies"); ?>" target="_blank">public page</a>. Optional.</p>
-                                                    <textarea data-editor="markdown" placeholder="Blurb" name="public_blurb" id="public_blurb" rows="20" cols="80" class="big_ace_editor form-control"><?= h($run->public_blurb); ?></textarea>
+                                                    <textarea data-editor="markdown" placeholder="Blurb" name="public_blurb" id="public_blurb" rows="10" cols="80" class="big_ace_editor form-control"><?= h($run->public_blurb); ?></textarea>
                                                 </div>
                                             </div>
                                         </div>
@@ -195,7 +195,7 @@
                                         <div class="row">
                                             <div class="col-md-12">
                                                 <div class="form-group">
-                                                    <textarea data-editor="css" placeholder="Enter your custom CSS here" name="custom_css" rows="20" cols="80" class="big_ace_editor form-control"><?= h($run->getCustomCSS()); ?></textarea>
+                                                    <textarea data-editor="css" placeholder="Enter your custom CSS here" name="custom_css" rows="40" cols="80" class="big_ace_editor form-control"><?= h($run->getCustomCSS()); ?></textarea>
                                                 </div>
                                             </div>
                                         </div>
@@ -214,7 +214,7 @@
                                         <div class="row">
                                             <div class="col-md-12">
                                                 <div class="form-group">
-                                                    <textarea data-editor="javascript" placeholder="Enter your custom JS here" name="custom_js" rows="20" cols="80" class="big_ace_editor form-control"><?= h($run->getCustomJS()); ?></textarea>
+                                                    <textarea data-editor="javascript" placeholder="Enter your custom JS here" name="custom_js" rows="40" cols="80" class="big_ace_editor form-control"><?= h($run->getCustomJS()); ?></textarea>
                                                 </div>
                                             </div>
                                         </div>
@@ -241,7 +241,7 @@
                                                     <textarea data-editor="r" placeholder="# Custom R functions &mdash; callable by name in showif, value, feedback, etc.
 my_score <- function(data) {
     mean(data, na.rm = TRUE)
-}" name="custom_r" rows="20" cols="80" class="big_ace_editor form-control"><?= h($run->getCustomRFunctions()); ?></textarea>
+}" name="custom_r" rows="40" cols="80" class="big_ace_editor form-control"><?= h($run->getCustomRFunctions()); ?></textarea>
                                                 </div>
                                             </div>
                                         </div>

--- a/templates/admin/run/settings.php
+++ b/templates/admin/run/settings.php
@@ -26,6 +26,7 @@
                                 <li><a href="#privacy" data-toggle="tab" aria-expanded="false">Privacy</a></li>
                                 <li><a href="#css" data-toggle="tab" aria-expanded="false">CSS</a></li>
                                 <li><a href="#js" data-toggle="tab" aria-expanded="false">JS</a></li>
+                                <li><a href="#rfunctions" data-toggle="tab" aria-expanded="false">R Functions</a></li>
                                 <li><a href="#manifest" data-toggle="tab" aria-expanded="false">App</a></li>
                                 <li><a href="#service_message" data-toggle="tab" aria-expanded="false">Service message</a></li>
                                 <li><a href="#reminder" data-toggle="tab" aria-expanded="false">Reminder</a></li>
@@ -213,6 +214,31 @@
                                             <div class="col-md-12">
                                                 <div class="form-group">
                                                     <textarea data-editor="javascript" placeholder="Enter your custom JS here" name="custom_js" rows="20" cols="80" class="big_ace_editor form-control"><?= h($run->getCustomJS()); ?></textarea>
+                                                </div>
+                                            </div>
+                                        </div>
+                                    </form>
+                                </div>
+                                <!-- /.tab-pane -->
+                                <div class="tab-pane" id="rfunctions">
+                                    <form enctype="multipart/form-data" method="post" action="<?php echo admin_run_url($run->name, 'ajax_save_settings'); ?>">
+                                        <p class="pull-right">
+                                            <input type="submit" name="submit_settings" value="Save" class="btn btn-primary save_settings">
+                                        </p>
+                                        <h4 class="lead"><i class="fa fa-cog"></i> R Functions</h4>
+                                        <p>
+                                            Define custom R functions here that will be available in every R evaluation context within this run
+                                            (showif, value, feedback, <code>relative_to</code>, branch conditions, external URLs, email body, etc.).
+                                            Functions are injected before your inline R code so you can call them by name.
+                                            Use standard R syntax &mdash; define named functions, load libraries, or set global options.
+                                        </p>
+                                        <div class="row">
+                                            <div class="col-md-12">
+                                                <div class="form-group">
+                                                    <textarea data-editor="r" placeholder="# Define your custom R functions here
+my_score <- function(data) {
+    mean(data, na.rm = TRUE)
+}" name="custom_r" rows="20" cols="80" class="big_ace_editor form-control"><?= h($run->getCustomRFunctions()); ?></textarea>
                                                 </div>
                                             </div>
                                         </div>

--- a/templates/admin/run/settings.php
+++ b/templates/admin/run/settings.php
@@ -224,7 +224,7 @@
                                 <div class="tab-pane" id="r-functions">
                                     <form enctype="multipart/form-data" method="post" action="<?php echo admin_run_url($run->name, 'ajax_save_settings'); ?>">
                                         <p class="pull-right">
-                                            <input type="submit" name="submit_settings" value="Save" class="btn btn-primary save_settings">
+                                            <button type="button" class="btn btn-primary btn-save-test-r-code">Save &amp; Test R Syntax</button>
                                         </p>
                                         <h4 class="lead"><i class="fa fa-cog"></i> R Functions</h4>
                                         <p>
@@ -235,6 +235,7 @@
                                             To access run data (survey results, <code>survey_unit_sessions</code>, etc.), pass them
                                             as arguments &mdash; functions cannot directly see variables defined in inline R code.
                                         </p>
+                                        <div id="r-code-parse-result"></div>
                                         <div class="row">
                                             <div class="col-md-12">
                                                 <div class="form-group">
@@ -660,6 +661,14 @@ qplot(survey_name$created) # plot entries by startdate</code></pre></li>
         }
     }, true);
 
+    // Enter key in name/value fields triggers add
+    document.getElementById('new-secret-name').addEventListener('keydown', function(e) {
+        if (e.key === 'Enter') { e.preventDefault(); document.getElementById('add-secret-btn').click(); }
+    });
+    document.getElementById('new-secret-value').addEventListener('keydown', function(e) {
+        if (e.key === 'Enter') { e.preventDefault(); document.getElementById('add-secret-btn').click(); }
+    });
+
     // Add new secret + auto-save
     document.getElementById('add-secret-btn').addEventListener('click', function() {
         var nameInput = document.getElementById('new-secret-name');
@@ -686,7 +695,102 @@ qplot(survey_name$created) # plot entries by startdate</code></pre></li>
 
         nameInput.value = '';
         valueInput.value = '';
+        nameInput.focus();
         saveSecrets();
+    });
+})();
+
+// --- Save & test R Syntax ---
+(function() {
+    var rForm = document.querySelector('#r-functions form');
+    var resultEl = document.getElementById('r-code-parse-result');
+    var validateUrl = '<?php echo admin_run_url($run->name, 'ajax_validate_r_code'); ?>';
+    if (!rForm || !resultEl) return;
+
+    var busy = false;
+    var lastCode = '';
+    var lastError = '';
+
+    function escapeHtml(text) {
+        var d = document.createElement('div');
+        d.appendChild(document.createTextNode(text));
+        return d.innerHTML;
+    }
+
+    rForm.querySelector('.btn-save-test-r-code').addEventListener('click', async function() {
+        if (busy) return;
+        busy = true;
+        jQuery(rForm).trigger('ajax_submission');
+        var textarea = rForm.querySelector('textarea[name="custom_r"]');
+        if (!textarea) { busy = false; return; }
+        var code = textarea.value;
+
+        resultEl.innerHTML = '<i class="fa fa-spinner fa-spin"></i> Saving…';
+
+        try {
+            var saveRes = await fetch(rForm.action, {
+                method: 'POST',
+                body: new FormData(rForm),
+                headers: { 'X-Requested-With': 'XMLHttpRequest' }
+            });
+            if (!saveRes.ok) {
+                busy = false;
+                resultEl.innerHTML = '<span class="text-warning"><i class="fa fa-warning"></i> Save failed</span>';
+                return;
+            }
+
+            var saveHtml = await saveRes.text();
+            if (saveHtml) {
+                var heading = document.getElementById('app_heading');
+                if (heading) {
+                    var tmp = document.createElement('div');
+                    tmp.innerHTML = saveHtml;
+                    while (tmp.firstChild) {
+                        heading.parentNode.insertBefore(tmp.firstChild, heading.nextSibling);
+                    }
+                }
+            }
+
+            if (code.trim() === '') {
+                busy = false;
+                resultEl.innerHTML = '';
+                return;
+            }
+
+            resultEl.innerHTML = '<i class="fa fa-spinner fa-spin"></i> Checking syntax…';
+            var fd = new FormData();
+            fd.append('r_code', code);
+            var checkRes = await fetch(validateUrl, {
+                method: 'POST',
+                body: fd,
+                headers: { 'X-Requested-With': 'XMLHttpRequest' }
+            });
+            var data = await checkRes.json();
+            busy = false;
+
+            if (data.valid === true) {
+                resultEl.innerHTML = '<span class="text-success"><i class="fa fa-check"></i> R syntax is valid</span>';
+            } else if (data.valid === false) {
+                lastCode = code;
+                lastError = data.message;
+                resultEl.innerHTML = '<pre class="text-danger" style="white-space: pre-wrap; margin: 8px 0">'
+                    + escapeHtml(data.message)
+                    + '</pre>'
+                    + '<div style="margin: 6px 0"><p class="pull-right"><button type="button" class="btn btn-sm btn-default" title="Copy code + error for LLM"><i class="fa fa-clipboard"></i> Copy for LLM</button></p></div>';
+                var copyBtn = resultEl.querySelector('button');
+                if (copyBtn) {
+                    copyBtn.addEventListener('click', function() {
+                        var text = 'TASK: Debug this R code syntax error.\n\nCODE:\n' + lastCode + '\n\nERROR:\n' + lastError;
+                        navigator.clipboard.writeText(text);
+                    });
+                }
+            } else {
+                resultEl.innerHTML = '<span class="text-warning"><i class="fa fa-warning"></i> ' + (data.message || 'Could not validate') + '</span>';
+            }
+        } catch (e) {
+            busy = false;
+            resultEl.innerHTML = '<span class="text-warning"><i class="fa fa-warning"></i> Save or syntax check failed</span>';
+        }
     });
 })();
 </script>

--- a/templates/admin/run/settings.php
+++ b/templates/admin/run/settings.php
@@ -34,32 +34,43 @@
                             </ul>
                             <div class="tab-content">
                                 <div class="tab-pane active" id="settings">
-                                    <form class="form-horizontal" enctype="multipart/form-data"  id="run_settings" method="post" action="<?php echo admin_run_url($run->name, 'ajax_save_settings'); ?>">
+                                    <form enctype="multipart/form-data" method="post" action="<?php echo admin_run_url($run->name, 'ajax_save_settings'); ?>">
                                         <p class="pull-right">
                                             <input type="submit" name="submit_settings" value="Save" class="btn btn-primary save_settings">
                                         </p>
-                                        <div class="col-md-12">
-                                            <div class="form-group">
-                                                <label title="Will be shown on every page of the run">Title</label>
-                                                <input type="text" maxlength="1000" placeholder="Title" name="title" class="form-control" value="<?= h($run->title); ?>" />
-                                            </div>
-                                            <div class="form-group">
-                                                <label title="Link to your header image, shown on every run page">Header image</label>
-                                                <input type="text" maxlength="255" placeholder="URL" name="header_image_path" class="form-control" value="<?= h($run->header_image_path); ?>" />
-                                            </div>
+                                        <h4 class="lead"><i class="fa fa-cog"></i> General Settings</h4>
 
-                                            <div class="form-group" style="margin-bottom: 15px;">
-                                                <div class="col-md-6">
+                                        <div class="row">
+                                            <div class="col-md-12">
+                                                <div class="form-group">
+                                                    <label title="Will be shown on every page of the run">Title</label>
+                                                    <input type="text" maxlength="1000" placeholder="Title" name="title" class="form-control" value="<?= h($run->title); ?>" />
+                                                </div>
+                                            </div>
+                                        </div>
+
+                                        <div class="row">
+                                            <div class="col-md-12">
+                                                <div class="form-group">
+                                                    <label title="Link to your header image, shown on every run page">Header image</label>
+                                                    <input type="text" maxlength="255" placeholder="URL" name="header_image_path" class="form-control" value="<?= h($run->header_image_path); ?>" />
+                                                </div>
+                                            </div>
+                                        </div>
+
+                                        <div class="row">
+                                            <div class="col-md-6">
+                                                <div class="form-group">
                                                     <label for="expiresOn">Expires On</label>
                                                     <p>If set, the data in this run will be deleted after the specified date. You will receive email reminders before this happens. Under <abbr title="General Data Protection Regulation">GDPR</abbr>, you are required to delete personal data once it is no longer necessary for the purpose for which it was collected. It is up to you to know what period of data retention is reasonable. <br>If you did not collect personal data, you do not need to delete data. However, do consider that even seemingly anonymous data can sometimes be combined with other data to identify individuals, so deletion may still be prudent.</p>
                                                     <p>The maximum expiry date is in <?php echo Config::get('keep_study_data_for_months_maximum'); ?> months.</p>
                                                     <input class="form-control" type="date" name="expiresOn" id="expiresOn" placeholder="<?php echo date('Y-m-d', strtotime('+' . Config::get('keep_study_data_for_months_maximum') . ' months')); ?>" value="<?php echo $run->expiresOn; ?>">
                                                </div>
-                                                <div class="col-md-6">
-                                                    <strong>Cookie/Session Lifetime</strong>
-                                                    <p>
-                                                        Configure how long a user session cookie will last. Once the cookie expires, the user will be logged out.
-                                                    </p>
+                                            </div>
+                                            <div class="col-md-6">
+                                                <div class="form-group">
+                                                    <label>Cookie/Session Lifetime</label>
+                                                    <p>Configure how long a user session cookie will last. Once the cookie expires, the user will be logged out.</p>
                                                     <div class="input-group">
                                                         <div class="input-group-addon"> Expire After </div>
                                                         <input type="number" class="form-control" name="expire_cookie_value" value="<?php echo $run->expire_cookie_value; ?>" />
@@ -74,58 +85,66 @@
                                                     </div>
                                                 </div>
                                             </div>
+                                        </div>
 
-
-                                            <div class="checkbox form-group"  style="margin-bottom: 15px;">
-                                                <div class="col-md-6">
-                                                    <strong>Automated actions</strong>
+                                        <div class="row">
+                                            <div class="col-md-6">
+                                                <div class="form-group">
+                                                    <label>Automated actions</label>
                                                     <p>Enable pause expiration, automatic email sending and other automated operations. Disable if automated actions are not desired, necessary or something seems to be going wrong.</p>
                                                     <label>
                                                         <input type="hidden" name="cron_active" value="0" />
                                                         <input type="checkbox" name="cron_active" <?= ($run->cron_active) ? 'checked' : '' ?> value="1"> Enable automated actions.
                                                     </label>
                                                 </div>
-                                                <div class="checkbox col-md-6">
-                                                    <strong>Look &amp; Feel</strong>
-                                                    <p>
-                                                        We previously offered an alternative style for surveys, <a target="_blank" href="https://fezvrasta.github.io/bootstrap-material-design/">Material Design</a>. To reduce maintenance burden, we have deprecated this option. If you previously enabled this option, you can still use it, but once you turn it off, you will not be able to turn it back on.
-                                                    </p>
+                                            </div>
+                                            <div class="col-md-6">
+                                                <div class="form-group">
+                                                    <label>Look &amp; Feel</label>
+                                                    <p>We previously offered an alternative style for surveys, <a target="_blank" href="https://fezvrasta.github.io/bootstrap-material-design/">Material Design</a>. To reduce maintenance burden, we have deprecated this option. If you previously enabled this option, you can still use it, but once you turn it off, you will not be able to turn it back on.</p>
                                                     <label title="Material Design style is deprecated as of v0.22.0.">
                                                         <input type="hidden" name="use_material_design" value="0" />
                                                         <input type="checkbox" name="use_material_design" <?= ($run->use_material_design) ? 'checked' : 'disabled' ?> value="1"> Enable Material Design.
                                                     </label>
-
                                                 </div>
                                             </div>
-                                            
-                                            <div class="form-group">
-                                                <label for="description">Description</label>
-                                                <p>Will be shown at the top of every page of the study. Optional.</p>
-                                                <textarea data-editor="markdown" placeholder="Description" name="description" id="description" rows="10" cols="80" class="big_ace_editor form-control"><?= h($run->description); ?></textarea>
-                                            </div>
-                                            <div class="form-group">
-                                                <p>Your Imprint should contain information about who is responsible for the study, and how they can be contacted. It should also link to your privacy policy and in some cases to the settings page, where users can unsubscribe from emails and log out.</p>
-                                                <label title="Will be shown on every page of the run, good for contact info" for="footer_text">Imprint/Footer text</label>
-                                                <textarea data-editor="markdown" placeholder="Footer text" name="footer_text" id="footer_text" rows="10" cols="80" class="big_ace_editor form-control"><?= h($run->footer_text); ?></textarea>
-                                            </div>
-                                            <div class="form-group">
-                                                <label title="This will be the description of your study shown on the public page" for="public_blurb">Public blurb</label>
-                                                <p>This will be the description of your study shown on the <a href="<?php echo site_url("/public/studies"); ?>" target="_blank">public page</a>. Optional.</p>
-                                                <textarea data-editor="markdown" placeholder="Blurb" name="public_blurb" id="public_blurb" rows="10" cols="80" class="big_ace_editor form-control"><?= h($run->public_blurb); ?></textarea>
-                                            </div>
+                                        </div>
 
-
-
+                                        <div class="row">
+                                            <div class="col-md-12">
+                                                <div class="form-group">
+                                                    <label for="description">Description</label>
+                                                    <p>Will be shown at the top of every page of the study. Optional.</p>
+                                                    <textarea data-editor="markdown" placeholder="Description" name="description" id="description" rows="20" cols="80" class="big_ace_editor form-control"><?= h($run->description); ?></textarea>
+                                                </div>
+                                            </div>
+                                        </div>
+                                        <div class="row">
+                                            <div class="col-md-12">
+                                                <div class="form-group">
+                                                    <p>Your Imprint should contain information about who is responsible for the study, and how they can be contacted. It should also link to your privacy policy and in some cases to the settings page, where users can unsubscribe from emails and log out.</p>
+                                                    <label title="Will be shown on every page of the run, good for contact info" for="footer_text">Imprint/Footer text</label>
+                                                    <textarea data-editor="markdown" placeholder="Footer text" name="footer_text" id="footer_text" rows="20" cols="80" class="big_ace_editor form-control"><?= h($run->footer_text); ?></textarea>
+                                                </div>
+                                            </div>
+                                        </div>
+                                        <div class="row">
+                                            <div class="col-md-12">
+                                                <div class="form-group">
+                                                    <label title="This will be the description of your study shown on the public page" for="public_blurb">Public blurb</label>
+                                                    <p>This will be the description of your study shown on the <a href="<?php echo site_url("/public/studies"); ?>" target="_blank">public page</a>. Optional.</p>
+                                                    <textarea data-editor="markdown" placeholder="Blurb" name="public_blurb" id="public_blurb" rows="20" cols="80" class="big_ace_editor form-control"><?= h($run->public_blurb); ?></textarea>
+                                                </div>
+                                            </div>
                                         </div>
                                     </form>
-                                    <div class="clear clearfix"></div>
                                 </div>
                                 <div class="tab-pane" id="privacy">
-                                    <form class="form-horizontal" enctype="multipart/form-data"  id="run_settings" method="post" action="<?php echo admin_run_url($run->name, 'ajax_save_settings'); ?>">
+                                    <form enctype="multipart/form-data" method="post" action="<?php echo admin_run_url($run->name, 'ajax_save_settings'); ?>">
                                         <p class="pull-right">
                                             <input type="submit" name="submit_settings" value="Save" class="btn btn-primary save_settings">
                                         </p>
-                                        <h4><i class="fa fa-vcard"></i> Privacy</h4>
+                                        <h4 class="lead"><i class="fa fa-vcard"></i> Privacy</h4>
                                         <p>
                                             The following settings are used by the Privacy Run Unit. They are used to inform users about the privacy policy, terms of service and imprint of your study.
                                             These are required by law in some countries. Add a Privacy Consent Unit to your run to make use of these settings.
@@ -134,256 +153,277 @@
                                         <p>
                                             A Privacy Policy and Imprint are required by law in some countries. That's why we require you to provide them.
                                         </p>
-                                        <div class="col-md-12">
-                                            <div class="form-group">
-                                                <p>
-                                                    Your Privacy Policy should contain information about the data you collect, how you collect it, how you store it, how you use it and how you protect it.
-                                                    You should also provide information about how users can contact you to request information about the data you have collected about them, and how they can request that you delete that data.
-                                                    For more information and a template, see <a href="https://gdpr.eu/privacy-notice/">the guide at gdpr.eu</a>.
-                                                </p>
-                                                <label title="Used by the Privacy Run Unit">Privacy Policy (<a href="<?php echo run_url($run->name, '', ['show-privacy-page' => 'privacy-policy']); ?>" target="_blank">View</a>)</label>
-                                                <textarea data-editor="markdown" placeholder="Privacy Policy" name="privacy" rows="10" cols="80" class="big_ace_editor form-control"><?= h($run->privacy); ?></textarea>
+                                        <div class="row">
+                                            <div class="col-md-12">
+                                                <div class="form-group">
+                                                    <p>
+                                                        Your Privacy Policy should contain information about the data you collect, how you collect it, how you store it, how you use it and how you protect it.
+                                                        You should also provide information about how users can contact you to request information about the data you have collected about them, and how they can request that you delete that data.
+                                                        For more information and a template, see <a href="https://gdpr.eu/privacy-notice/">the guide at gdpr.eu</a>.
+                                                    </p>
+                                                    <label title="Used by the Privacy Run Unit">Privacy Policy (<a href="<?php echo run_url($run->name, '', ['show-privacy-page' => 'privacy-policy']); ?>" target="_blank">View</a>)</label>
+                                                    <textarea data-editor="markdown" placeholder="Privacy Policy" name="privacy" rows="20" cols="80" class="big_ace_editor form-control"><?= h($run->privacy); ?></textarea>
+                                                </div>
                                             </div>
-                                            <div class="form-group">
-                                                <p>
-                                                    Your Terms of Service should contain information about how users are allowed to use your study, and what they are not allowed to do.
-                                                </p>
-                                                <label title="Used by the Privacy Run Unit">Terms of Service (<a href="<?php echo run_url($run->name, '', ['show-privacy-page' => 'terms-of-service']); ?>" target="_blank">View</a>)</label>
-                                                <textarea data-editor="markdown" placeholder="Terms of Service" name="tos" rows="10" cols="80" class="big_ace_editor form-control"><?= h($run->tos); ?></textarea>
+                                        </div>
+                                        <div class="row">
+                                            <div class="col-md-12">
+                                                <div class="form-group">
+                                                    <p>
+                                                        Your Terms of Service should contain information about how users are allowed to use your study, and what they are not allowed to do.
+                                                    </p>
+                                                    <label title="Used by the Privacy Run Unit">Terms of Service (<a href="<?php echo run_url($run->name, '', ['show-privacy-page' => 'terms-of-service']); ?>" target="_blank">View</a>)</label>
+                                                    <textarea data-editor="markdown" placeholder="Terms of Service" name="tos" rows="20" cols="80" class="big_ace_editor form-control"><?= h($run->tos); ?></textarea>
+                                                </div>
                                             </div>
                                         </div>
                                     </form>
-                                    <div class="clear clearfix"></div>
                                 </div>
                                 <!-- /.tab-pane -->
                                 <div class="tab-pane" id="css">
-                                    <form class="form-horizontal" enctype="multipart/form-data"  id="run_settings" method="post" action="<?php echo admin_run_url($run->name, 'ajax_save_settings'); ?>">
+                                    <form enctype="multipart/form-data" method="post" action="<?php echo admin_run_url($run->name, 'ajax_save_settings'); ?>">
                                         <p class="pull-right">
                                             <input type="submit" name="submit_settings" value="Save" class="btn btn-primary save_settings">
                                         </p>
-                                        <h4><i class="fa fa-css3"></i> Cascading style sheets</h4>
+                                        <h4 class="lead"><i class="fa fa-css3"></i> Cascading style sheets</h4>
                                         <p>
                                             CSS allows you to apply custom styles to every page of your study. If you want to limit styles to
                                             certain pages, you can use CSS classes referring to either position in the run (e.g. <code class="css">.run_position_10 {}</code>) or module type (e.g. <code class="css">.run_unit_type_Survey {}</code>). Learn about <a href="https://developer.mozilla.org/en-US/docs/Learn/CSS/First_steps/Getting_started">CSS at Mozilla Developer Network</a>. A chat bot could also help you get the requested result.
                                         </p>
-                                        <div class="form-group col-md-12">
-                                            <textarea data-editor="css" placeholder="Enter your custom CSS here" name="custom_css" rows="40" cols="80" class="big_ace_editor form-control"><?= h($run->getCustomCSS()); ?></textarea>
+                                        <div class="row">
+                                            <div class="col-md-12">
+                                                <div class="form-group">
+                                                    <textarea data-editor="css" placeholder="Enter your custom CSS here" name="custom_css" rows="20" cols="80" class="big_ace_editor form-control"><?= h($run->getCustomCSS()); ?></textarea>
+                                                </div>
+                                            </div>
                                         </div>
-
                                     </form>
-                                    <div class="clear clearfix"></div>
                                 </div>
                                 <!-- /.tab-pane -->
                                 <div class="tab-pane" id="js">
-                                    <form class="form-horizontal" enctype="multipart/form-data"  id="run_settings" method="post" action="<?php echo admin_run_url($run->name, 'ajax_save_settings'); ?>">
+                                    <form enctype="multipart/form-data" method="post" action="<?php echo admin_run_url($run->name, 'ajax_save_settings'); ?>">
                                         <p class="pull-right">
                                             <input type="submit" name="submit_settings" value="Save" class="btn btn-primary save_settings">
                                         </p>
-                                        <h4><i class="fa fa-javascript"></i> JavaScript</h4>
+                                        <h4 class="lead"><i class="fa fa-code"></i> JavaScript</h4>
                                         <p>
                                             Javascript allows you to apply custom scripts to every page of your study. This is a fully-fledged programming language. You can use it to make things move, give dynamic hints to the user and so on. Learn about <a href="https://www.codecademy.com/tracks/javascript">JS at Codecademy.com</a>.
                                         </p>
-                                        <div class="form-group col-md-12">
-                                            <textarea data-editor="javascript" placeholder="Enter your custom JS here" name="custom_js" rows="40" cols="80" class="big_ace_editor form-control"><?= h($run->getCustomJS()); ?></textarea>
+                                        <div class="row">
+                                            <div class="col-md-12">
+                                                <div class="form-group">
+                                                    <textarea data-editor="javascript" placeholder="Enter your custom JS here" name="custom_js" rows="20" cols="80" class="big_ace_editor form-control"><?= h($run->getCustomJS()); ?></textarea>
+                                                </div>
+                                            </div>
                                         </div>
-
                                     </form>
-                                    <div class="clear clearfix"></div>
                                 </div>
                                 <!-- /.tab-pane -->
                                 <div class="tab-pane" id="manifest">
-                                <h3 id="app_heading">App</h3>
-                                <p>Formr studies can be installed as a PWA (Progressive Web App) on the home screen. This allows you to send push notifications to users to invite them to return to the study, e.g. for experience sampling studies. </p>
-                                <h4><i class="fa fa-folder-open"></i> PWA Icons & Splash Screens</h4>
-                                    <form class="form-horizontal" enctype="multipart/form-data" id="pwa_icons_form" method="post" action="<?php echo admin_run_url($run->name, 'ajax_upload_pwa_icon_folder'); ?>">
-                                        <div class="form-group col-md-12">
-                                            <label for="pwa_icon_folder_input">Upload PWA Icon/Splash Screen Folder</label>
-                                            <p>
-                                                Upload a folder containing your PWA icons and splash screens (e.g., <code>icon.png</code>, <code>maskable_icon.png</code>, <code>apple-touch-icon.png</code>, <code>iPhone_XR_portrait.png</code>, etc.).
-                                                This will replace any previously uploaded PWA icon set. The specific filenames needed are referenced in the manifest (see above) and by the system for apple touch icons. 
-                                                The uploaded folder's path will be stored. Ensure the filenames within your folder match those expected. You can use <a href="https://progressier.com/pwa-icons-and-ios-splash-screen-generator">this tool</a> to generate these images from one image with the right file names.
-                                            </p>
-                                            <input type="file" name="pwa_icon_files[]" id="pwa_icon_folder_input" webkitdirectory directory multiple class="form-control">
-                                            <?php if ($run->getPwaIconPath()): ?>
-                                                <p class="help-block">Currently set PWA icon path: <code><?php echo h($run->getPwaIconPath()); ?></code></p>
-                                            <?php endif; ?>
-                                        </div>
-                                        <div class="form-group col-md-12">
-                                            <button type="submit" class="btn btn-primary"><i class="fa fa-upload"></i> Upload PWA Icon Folder</button>
-                                            <?php if ($run->getPwaIconPath()): ?>
-                                                <button type="button" id="clear_pwa_icons_button" data-action-url="<?php echo admin_run_url($run->name, 'ajax_clear_pwa_icons'); ?>" class="btn btn-danger pull-right"><i class="fa fa-trash"></i> Clear PWA Icons</button>
-                                            <?php endif; ?>
+                                    <h4 class="lead" id="app_heading"><i class="fa fa-mobile"></i> App</h4>
+                                    <p>Formr studies can be installed as a PWA (Progressive Web App) on the home screen. This allows you to send push notifications to users to invite them to return to the study, e.g. for experience sampling studies. </p>
+                                    <h4 class="lead"><i class="fa fa-folder-open"></i> PWA Icons & Splash Screens</h4>
+                                    <form enctype="multipart/form-data" id="pwa_icons_form" method="post" action="<?php echo admin_run_url($run->name, 'ajax_upload_pwa_icon_folder'); ?>">
+                                        <div class="row">
+                                            <div class="col-md-12">
+                                                <div class="form-group">
+                                                    <label for="pwa_icon_folder_input">Upload PWA Icon/Splash Screen Folder</label>
+                                                    <p>
+                                                        Upload a folder containing your PWA icons and splash screens (e.g., <code>icon.png</code>, <code>maskable_icon.png</code>, <code>apple-touch-icon.png</code>, <code>iPhone_XR_portrait.png</code>, etc.).
+                                                        This will replace any previously uploaded PWA icon set. The specific filenames needed are referenced in the manifest (see above) and by the system for apple touch icons. 
+                                                        The uploaded folder's path will be stored. Ensure the filenames within your folder match those expected. You can use <a href="https://progressier.com/pwa-icons-and-ios-splash-screen-generator">this tool</a> to generate these images from one image with the right file names.
+                                                    </p>
+                                                    <input type="file" name="pwa_icon_files[]" id="pwa_icon_folder_input" webkitdirectory directory multiple class="form-control">
+                                                    <?php if ($run->getPwaIconPath()): ?>
+                                                        <p class="help-block">Currently set PWA icon path: <code><?php echo h($run->getPwaIconPath()); ?></code></p>
+                                                    <?php endif; ?>
+                                                </div>
+                                                <div class="form-group">
+                                                    <button type="submit" class="btn btn-primary"><i class="fa fa-upload"></i> Upload PWA Icon Folder</button>
+                                                    <?php if ($run->getPwaIconPath()): ?>
+                                                        <button type="button" id="clear_pwa_icons_button" data-action-url="<?php echo admin_run_url($run->name, 'ajax_clear_pwa_icons'); ?>" class="btn btn-danger pull-right"><i class="fa fa-trash"></i> Clear PWA Icons</button>
+                                                    <?php endif; ?>
+                                                </div>
+                                            </div>
                                         </div>
                                     </form>
                                     <hr />
 
-                                
-                                    <form class="form-horizontal" enctype="multipart/form-data" id="run_settings" method="post" action="<?php echo admin_run_url($run->name, 'ajax_save_settings'); ?>">
+                                    <form enctype="multipart/form-data" method="post" action="<?php echo admin_run_url($run->name, 'ajax_save_settings'); ?>">
                                         <p class="pull-right">
                                             <button data-href="<?php echo admin_run_url($run->name, 'ajax_generate_manifest'); ?>" class="btn btn-default generate-manifest"><i class="fa fa-magic"></i> Generate Manifest</button>
                                             <input type="submit" name="submit_settings" value="Save Manifest Text" class="btn btn-primary save_settings">
                                         </p>
-                                        <h4><i class="fa fa-cogs"></i> App Manifest</h4>
+                                        <h4 class="lead"><i class="fa fa-cogs"></i> App Manifest</h4>
                                         <p>
                                             To make PWAs work, you need to generate a manifest.json file in the study/run settings. Just click the button with the magic wand to generate a manifest.json file based on your run settings. You can then customize it further. A manifest.json file is required for the PWA (adding to home screen, push notifications) to work.
                                         </p>
                                         <p>
                                             If you don't eschew the effort, you can package your PWA and distribute via one of the app stores. For a report on your PWA, customize your manifest, make your study public and see <a href="https://www.pwabuilder.com/reportcard?site=<?php echo run_url($run->name); ?>" target="_blank">PWA report on PWA Builder</a>.
                                         </p>
-
-                                    
-                                        <div class="form-group col-md-12">
-                                            <textarea data-editor="json" placeholder="Enter your manifest JSON here" name="manifest_json"  id="manifest_json" rows="25" cols="80" class="big_ace_editor form-control"><?= h($run->getManifestJSON()); ?></textarea>
+                                        <div class="row">
+                                            <div class="col-md-12">
+                                                <div class="form-group">
+                                                    <textarea data-editor="json" placeholder="Enter your manifest JSON here" name="manifest_json" id="manifest_json" rows="20" cols="80" class="big_ace_editor form-control"><?= h($run->getManifestJSON()); ?></textarea>
+                                                </div>
+                                            </div>
                                         </div>
                                     </form>
-
-                                    <div class="clear clearfix"></div>
                                 </div>
                                 <div class="tab-pane" id="service_message">
-                                    <div class="col-md-12">
-                                        <div class="add">
-                                            <h3><i class="fa fa-eject"></i> Edit service message</h3>
-                                            <ul class="fa-ul fa-ul-more-padding">
-                                                <li><i class="fa-li fa fa-cog fa-lg fa-spin"></i> If you are making changes to your run, while it's live, you may want to keep your users from using it at the time. <br>Use this message to let them know that the run will be working again soon.</li>
-                                                <li><i class="fa-li fa fa-lg fa-stop"></i> You can also use this message to end a study, so that no new users will be admitted and old users who are not finished cannot go on.</li>
-                                            </ul>
-                                            <?php if (empty($service_messages)): ?>
-                                                <a href="<?= admin_run_url($run->name, 'create_run_unit?type=Page&special=ServiceMessagePage&redirect=settings:::service_message') ?>" class="btn btn-default pull-right add_run_unit"><i class="fa fa-plus"></i> Add Service Message</a>
-                                            <?php endif; ?>
-                                        </div>
-                                        <div class="clearfix"></div>
-                                        <div class="row special-units  reminder-cells">
-                                            <?php foreach ($service_messages as $message): ?>
-                                                <div class="col-md-11 single_unit_display">
-                                                    <form class="form-horizontal edit_run" enctype="multipart/form-data" name="edit_run" method="post" action="<?php echo admin_run_url($run->name); ?>" data-units='<?php echo json_encode($message['html_units']); ?>'>
-                                                        <div class="run_units"></div>
-                                                    </form>
-                                                </div>
-                                            <?php endforeach; ?>
+                                    <div class="row">
+                                        <div class="col-md-12">
+                                            <div class="add">
+                                                <h4 class="lead"><i class="fa fa-eject"></i> Edit service message</h4>
+                                                <ul class="fa-ul fa-ul-more-padding">
+                                                    <li><i class="fa-li fa fa-cog fa-lg fa-spin"></i> If you are making changes to your run, while it's live, you may want to keep your users from using it at the time. <br>Use this message to let them know that the run will be working again soon.</li>
+                                                    <li><i class="fa-li fa fa-lg fa-stop"></i> You can also use this message to end a study, so that no new users will be admitted and old users who are not finished cannot go on.</li>
+                                                </ul>
+                                                <?php if (empty($service_messages)): ?>
+                                                    <p class="text-muted"><em>You have no service messages yet.</em></p>
+                                                    <a href="<?= admin_run_url($run->name, 'create_run_unit?type=Page&special=ServiceMessagePage&redirect=settings:::service_message') ?>" class="btn btn-default pull-right add_run_unit"><i class="fa fa-plus"></i> Add Service Message</a>
+                                                <?php endif; ?>
+                                            </div>
+                                            <div class="clearfix"></div>
+                                            <div class="row special-units  reminder-cells">
+                                                <?php foreach ($service_messages as $message): ?>
+                                                    <div class="col-md-11 single_unit_display">
+                                                        <form class="form-horizontal edit_run" enctype="multipart/form-data" name="edit_run" method="post" action="<?php echo admin_run_url($run->name); ?>" data-units='<?php echo json_encode($message['html_units']); ?>'>
+                                                            <div class="run_units"></div>
+                                                        </form>
+                                                    </div>
+                                                <?php endforeach; ?>
+                                            </div>
                                         </div>
                                     </div>
-                                    <div class="clear clearfix"></div>
                                 </div>
                                 <div class="tab-pane" id="reminder">
-                                    <div class="col-md-12">
-                                        <div class="add">
-                                            <h3><i class="fa fa-bullhorn"></i> Add/Modify Email Reminders</h3>
-                                            <p>
-                                                Modify the text of a reminder, which you can then send to any user using the <i class="fa fa-bullhorn"></i> reminder button in the <a href="<?php echo admin_run_url($run->name, 'user_overview'); ?>">user overview</a>.
-                                            </p>
-                                            <a href="<?= admin_run_url($run->name, 'create_run_unit?type=Email&special=ReminderEmail&redirect=settings:::reminder') ?>" class="btn btn-default pull-right add_run_unit"><i class="fa fa-plus"></i> Add Reminder</a>
-                                        </div>
-                                        <div class="clearfix"></div>
-                                        <div class="row special-units  reminder-cells">
-                                            <?php foreach ($reminders as $reminder): ?>
-                                                <div class="col-md-6 single_unit_display">
-                                                    <form class="form-horizontal edit_run" enctype="multipart/form-data" name="edit_run" method="post" action="<?php echo admin_run_url($run->name); ?>" data-units='<?php echo json_encode($reminder['html_units']); ?>'>
-                                                        <a href="<?= admin_run_url($run->name, 'delete_run_unit?type=Email&special=ReminderEmail&redirect=settings:::reminder&unit_id=' . $reminder['id']) ?>" class="reminder-delete remove_unit_from_run" data-action="<?php echo admin_run_url($run->name); ?>" data-id="<?php echo $reminder['id']; ?>"><i class="fa fa-2x fa-trash"></i></a>
-                                                        <div class="run_units"></div>
-                                                    </form>
-                                                </div>
-                                            <?php endforeach; ?>
+                                    <div class="row">
+                                        <div class="col-md-12">
+                                            <div class="add">
+                                                <h4 class="lead"><i class="fa fa-bullhorn"></i> Add/Modify Email Reminders</h4>
+                                                <p>
+                                                    Modify the text of a reminder, which you can then send to any user using the <i class="fa fa-bullhorn"></i> reminder button in the <a href="<?php echo admin_run_url($run->name, 'user_overview'); ?>">user overview</a>.
+                                                </p>
+                                                <?php if (empty($reminders)): ?>
+                                                    <p class="text-muted"><em>You have no reminders yet.</em></p>
+                                                <?php endif; ?>
+                                                <a href="<?= admin_run_url($run->name, 'create_run_unit?type=Email&special=ReminderEmail&redirect=settings:::reminder') ?>" class="btn btn-default pull-right add_run_unit"><i class="fa fa-plus"></i> Add Reminder</a>
+                                            </div>
+                                            <div class="clearfix"></div>
+                                            <div class="row special-units reminder-cells">
+                                                <?php foreach ($reminders as $reminder): ?>
+                                                    <div class="col-md-6 single_unit_display">
+                                                        <form class="form-horizontal edit_run" enctype="multipart/form-data" name="edit_run" method="post" action="<?php echo admin_run_url($run->name); ?>" data-units='<?php echo json_encode($reminder['html_units']); ?>'>
+                                                            <a href="<?= admin_run_url($run->name, 'delete_run_unit?type=Email&special=ReminderEmail&redirect=settings:::reminder&unit_id=' . $reminder['id']) ?>" class="reminder-delete remove_unit_from_run" data-action="<?php echo admin_run_url($run->name); ?>" data-id="<?php echo $reminder['id']; ?>"><i class="fa fa-2x fa-trash"></i></a>
+                                                            <div class="run_units"></div>
+                                                        </form>
+                                                    </div>
+                                                <?php endforeach; ?>
+                                            </div>
                                         </div>
                                     </div>
-                                    <div class="clear clearfix"></div>
                                 </div>
                                 <div class="tab-pane" id="overview_script">
                                     <div class="row">
-                                        <div class="add">
-                                            <h3><i class="fa fa-eye"></i> Edit overview script</h3>
-                                            <ul class="fa-ul fa-ul-more-padding">
-                                                <li><i class="fa-li fa fa-code"></i> In here, you can use Markdown and R interspersed to make a custom overview for your study.</li>
-                                                <li><i class="fa-li fa fa-lg fa-thumb-tack"></i> Useful commands to start might be <pre><code class="r">nrow(survey_name) # get the number of entries
+                                        <div class="col-md-12">
+                                            <div class="add">
+                                                <h4 class="lead"><i class="fa fa-eye"></i> Edit overview script</h4>
+                                                <ul class="fa-ul fa-ul-more-padding">
+                                                    <li><i class="fa-li fa fa-code"></i> In here, you can use Markdown and R interspersed to make a custom overview for your study.</li>
+                                                    <li><i class="fa-li fa fa-lg fa-thumb-tack"></i> Useful commands to start might be <pre><code class="r">nrow(survey_name) # get the number of entries
 table(is.na(survey_name$ended)) # get finished/unfinished entries
 table(is.na(survey_name$modified)) # get entries where any data was entered vs not
 library(ggplot2)
 qplot(survey_name$created) # plot entries by startdate</code></pre></li>
-                                            </ul>
-                                            <?php if (empty($overview_scripts)): ?>
-                                                <a href="<?= admin_run_url($run->name, 'create_run_unit?type=Page&special=OverviewScriptPage&redirect=settings:::overview_script') ?>" class="btn btn-default pull-right add_run_unit"><i class="fa fa-plus"></i> Add Overview Script</a>
-                                            <?php endif; ?>
-                                        </div>
-                                        <div class="clearfix"></div>
-                                        <div class="row special-units  reminder-cells">
-                                            <?php foreach ($overview_scripts as $script): ?>
-                                                <div class="col-md-11 single_unit_display">
-                                                    <form class="form-horizontal edit_run" enctype="multipart/form-data" name="edit_run" method="post" action="<?php echo admin_run_url($run->name); ?>" data-units='<?php echo json_encode($script['html_units']); ?>'>
-                                                        <div class="run_units"></div>
-                                                    </form>
-                                                </div>
-                                            <?php endforeach; ?>
+                                                </ul>
+                                                <?php if (empty($overview_scripts)): ?>
+                                                    <p class="text-muted"><em>You have no overview scripts yet.</em></p>
+                                                    <a href="<?= admin_run_url($run->name, 'create_run_unit?type=Page&special=OverviewScriptPage&redirect=settings:::overview_script') ?>" class="btn btn-default pull-right add_run_unit"><i class="fa fa-plus"></i> Add Overview Script</a>
+                                                <?php endif; ?>
+                                            </div>
+                                            <div class="clearfix"></div>
+                                            <div class="row special-units reminder-cells">
+                                                <?php foreach ($overview_scripts as $script): ?>
+                                                    <div class="col-md-11 single_unit_display">
+                                                        <form class="form-horizontal edit_run" enctype="multipart/form-data" name="edit_run" method="post" action="<?php echo admin_run_url($run->name); ?>" data-units='<?php echo json_encode($script['html_units']); ?>'>
+                                                            <div class="run_units"></div>
+                                                        </form>
+                                                    </div>
+                                                <?php endforeach; ?>
+                                            </div>
                                         </div>
                                     </div>
-                                    <div class="clear clearfix"></div>
                                 </div>
                                 <div class="tab-pane" id="osf">
-                                    <div class="col-md-12">
-                                        <div class="single_unit_display">
-                                            <?php if (empty($osf_token)): ?>
-                                                <p>
+                                    <div class="row">
+                                        <div class="col-md-12">
+                                            <div class="single_unit_display">
+                                                <?php if (empty($osf_token)): ?>
+                                                    <h4 class="lead"><i class="fa fa-link"></i> Open Science Framework</h4>
+                                                    <p>
+                                                        <a href="<?php echo site_url('api/osf/login?redirect=admin/run/' . $run->name . '/settings'); ?>" class="btn btn-default"><i class="fa fa-link"></i> Connect to the &nbsp;<img src="<?= asset_url('build/img/osf-icon.png') ?>" alt="OSF Icon" /> <b>Open Science Framework</b></a>
+                                                    </p>
+                                                <?php else: ?>
                                                     <br /><br />
-                                                    <a href="<?php echo site_url('api/osf/login?redirect=admin/run/' . $run->name . '/settings'); ?>" class="btn btn-default"><i class="fa fa-link"></i> Connect to the &nbsp;<img src="<?= asset_url('build/img/osf-icon.png') ?>" alt="OSF Icon" /> <b>Open Science Framework</b></a>
-                                                </p>
-                                            <?php else: ?>
-                                                <br /><br />
-                                                <div class="panel panel-default" id="panel1">
-                                                    <div class="panel-heading">
-                                                        <h4 class="panel-title">
-                                                            <a data-toggle="collapse" data-target="#collapseOne"  href="#collapseOne"><i class="fa fa-cloud-upload"></i> Export run structure to OSF project </a>
-                                                        </h4>
-                                                    </div>
-                                                    <div id="collapseOne" class="panel-collapse collapse in">
-                                                        <div class="panel-body">
-                                                            <form action="<?php echo admin_url('osf'); ?>" method="post" >
-                                                                <div class="alert alert-info alert-dismissible">
-                                                                    <a href="#" class="close" data-dismiss="alert" aria-label="close" title="close">&times;</a>
-                                                                    <i class="fa fa-exclamation-circle"></i> In order to be able to export your <i>run</i> structure to the Open Science Framework,
-                                                                    you will first need to create a project on the OSF platform, and then select the corresponding project from the list below.
-                                                                    You may need to refresh this page to see a list of newly created projects.
-                                                                </div>
+                                                    <div class="panel panel-default" id="panel1">
+                                                        <div class="panel-heading">
+                                                            <h4 class="panel-title">
+                                                                <a data-toggle="collapse" data-target="#collapseOne" href="#collapseOne"><i class="fa fa-cloud-upload"></i> Export run structure to OSF project </a>
+                                                            </h4>
+                                                        </div>
+                                                        <div id="collapseOne" class="panel-collapse collapse in">
+                                                            <div class="panel-body">
+                                                                <form action="<?php echo admin_url('osf'); ?>" method="post">
+                                                                    <div class="alert alert-info alert-dismissible">
+                                                                        <a href="#" class="close" data-dismiss="alert" aria-label="close" title="close">&times;</a>
+                                                                        <i class="fa fa-exclamation-circle"></i> In order to be able to export your <i>run</i> structure to the Open Science Framework,
+                                                                        you will first need to create a project on the OSF platform, and then select the corresponding project from the list below.
+                                                                        You may need to refresh this page to see a list of newly created projects.
+                                                                    </div>
 
-                                                                <table class="table table-responsive">
-                                                                    <thead>
-                                                                        <tr>
-                                                                            <th>Select OSF Project</th>
-                                                                            <th><a class="btn btn-default pull-right" href="<?php echo Config::get('osf.site_url'); ?>" target="_blank"><img src="<?= asset_url('build/img/osf-icon.png') ?>" alt="OSF Icon" /> Create an OSF project</a></th>
-                                                                        </tr>
-                                                                    </thead>
-                                                                    <tbody>
-                                                                        <tr>
-                                                                            <td>
-                                                                                <div class="input-group">
-                                                                                    <span class="input-group-addon"><i class="fa fa-rocket"></i></span>
-                                                                                    <div class="form-group">
-                                                                                        <select name="osf_project" class="form-control">
-                                                                                            <option value="">....</option>
-                                                                                            <?php
-                                                                                            foreach ($osf_projects as $project):
-                                                                                                $selected = $project['id'] == $osf_project ? 'selected="selected"' : null
-                                                                                                ?>
-                                                                                                <option value="<?= $project['id']; ?>" <?= $selected ?>><?= $project['name']; ?> </option>
-                                                                                            <?php endforeach; ?>
-                                                                                        </select>          
+                                                                    <table class="table table-responsive">
+                                                                        <thead>
+                                                                            <tr>
+                                                                                <th>Select OSF Project</th>
+                                                                                <th><a class="btn btn-default pull-right" href="<?php echo Config::get('osf.site_url'); ?>" target="_blank"><img src="<?= asset_url('build/img/osf-icon.png') ?>" alt="OSF Icon" /> Create an OSF project</a></th>
+                                                                            </tr>
+                                                                        </thead>
+                                                                        <tbody>
+                                                                            <tr>
+                                                                                <td>
+                                                                                    <div class="input-group">
+                                                                                        <span class="input-group-addon"><i class="fa fa-rocket"></i></span>
+                                                                                        <div class="form-group">
+                                                                                            <select name="osf_project" class="form-control">
+                                                                                                <option value="">....</option>
+                                                                                                <?php
+                                                                                                foreach ($osf_projects as $project):
+                                                                                                    $selected = $project['id'] == $osf_project ? 'selected="selected"' : null
+                                                                                                    ?>
+                                                                                                    <option value="<?= $project['id']; ?>" <?= $selected ?>><?= $project['name']; ?> </option>
+                                                                                                <?php endforeach; ?>
+                                                                                            </select>          
+                                                                                        </div>
                                                                                     </div>
-                                                                                </div>
-                                                                            </td>
-                                                                            <td class="col-md-5">
-                                                                                <input type="hidden" name="formr_project" value="<?php echo $run->name; ?>" />
-                                                                                <input type="hidden" name="osf_action" value="export-run" />
-                                                                                <input type="hidden" name="redirect" value="admin/run/<?= $run->name ?>/settings#osf" />
-                                                                                <button type="submit" class="btn btn-primary btn-large"><i class="fa fa-mail-forward"></i> Export</button>
-                                                                            </td>
-                                                                        </tr>
-                                                                    </tbody>
-                                                                </table>
-                                                            </form>
-                                                        </div>	
+                                                                                </td>
+                                                                                <td class="col-md-5">
+                                                                                    <input type="hidden" name="formr_project" value="<?php echo $run->name; ?>" />
+                                                                                    <input type="hidden" name="osf_action" value="export-run" />
+                                                                                    <input type="hidden" name="redirect" value="admin/run/<?= $run->name ?>/settings#osf" />
+                                                                                    <button type="submit" class="btn btn-primary btn-large"><i class="fa fa-mail-forward"></i> Export</button>
+                                                                                </td>
+                                                                            </tr>
+                                                                        </tbody>
+                                                                    </table>
+                                                                </form>
+                                                            </div>	
+                                                        </div>
                                                     </div>
-                                                </div>
-                                            <?php endif; ?>
+                                                <?php endif; ?>
+                                            </div>
                                         </div>
                                     </div>
-                                    <div class="clear clearfix"></div>
                                 </div>
                             </div>
                             <!-- /.tab-content -->

--- a/templates/admin/run/settings.php
+++ b/templates/admin/run/settings.php
@@ -252,14 +252,24 @@ my_score <- function(data) {
                                     <div id="secrets-alerts"></div>
                                     <h4 class="lead"><i class="fa fa-lock"></i> Secrets</h4>
                                     <p>
-                                        Define sensitive values (API keys, tokens, passwords) here. They are <strong>encrypted at rest</strong>
-                                        in the database and <strong>automatically redacted</strong> from all logs, debug output, error messages,
+                                        Define sensitive values (API keys, tokens, passwords) here. They are <strong>stored encrypted</strong>
+                                        in the database and <strong>automatically hidden</strong> from all logs, debug output, error messages,
                                         run exports, and API responses. Changes are saved immediately.
                                     </p>
                                     <p>
-                                        In your R code (showif, value, feedback, etc.), access secrets as
+                                        In your R code (showif, value, label, body, subject, condition, etc.), access a secret as
                                         <code>.formr$secret_&lt;name&gt;</code> &mdash; for example, a secret named
                                         <code>api_key</code> is available as <code>.formr$secret_api_key</code>.
+                                        Secrets are <strong>only sent to the R environment</strong> when your code literally contains
+                                        that <code>.formr$secret_&lt;name&gt;</code> reference — unused secrets stay in the database
+                                        and are never transmitted to OpenCPU. References constructed dynamically at runtime
+                                        (e.g. <code>get(paste0(".formr$secret_", var))</code>) won't trigger injection;
+                                        always use the literal <code>.formr$secret_&lt;name&gt;</code> form.
+                                    </p>
+                                    <p class="text-muted small">
+                                        <i class="fa fa-info-circle"></i> This is <strong>not</strong> where to put your formr v1 API secret.
+                                        The formr API uses OAuth2 access tokens generated automatically via
+                                        <code>formr_api_authenticate()</code> &mdash; no manual secret entry needed.
                                     </p>
                                     <div id="secrets-save-indicator" class="text-muted" style="visibility: hidden; height: 22px; margin-bottom: 10px;"><i class="fa fa-spinner fa-spin"></i> Saving...</div>
                                     <div class="row">

--- a/templates/admin/run/settings.php
+++ b/templates/admin/run/settings.php
@@ -26,7 +26,7 @@
                                 <li><a href="#privacy" data-toggle="tab" aria-expanded="false">Privacy</a></li>
                                 <li><a href="#css" data-toggle="tab" aria-expanded="false">CSS</a></li>
                                 <li><a href="#js" data-toggle="tab" aria-expanded="false">JS</a></li>
-                                <li><a href="#rfunctions" data-toggle="tab" aria-expanded="false">R Functions</a></li>
+                                <li><a href="#r-functions-secrets" data-toggle="tab" aria-expanded="false">R Functions &amp; Secrets</a></li>
                                 <li><a href="#manifest" data-toggle="tab" aria-expanded="false">App</a></li>
                                 <li><a href="#service_message" data-toggle="tab" aria-expanded="false">Service message</a></li>
                                 <li><a href="#reminder" data-toggle="tab" aria-expanded="false">Reminder</a></li>
@@ -220,27 +220,37 @@
                                     </form>
                                 </div>
                                 <!-- /.tab-pane -->
-                                <div class="tab-pane" id="rfunctions">
+                                <div class="tab-pane" id="r-functions-secrets">
                                     <form enctype="multipart/form-data" method="post" action="<?php echo admin_run_url($run->name, 'ajax_save_settings'); ?>">
                                         <p class="pull-right">
                                             <input type="submit" name="submit_settings" value="Save" class="btn btn-primary save_settings">
                                         </p>
-                                        <h4 class="lead"><i class="fa fa-cog"></i> R Functions</h4>
+                                        <h4 class="lead"><i class="fa fa-cog"></i> R Functions &amp; Secrets</h4>
                                         <p>
-                                            Define custom R functions here that will be available in every R evaluation context within this run
-                                            (showif, value, feedback, <code>relative_to</code>, branch conditions, external URLs, email body, etc.).
-                                            Functions are injected before your inline R code so you can call them by name.
-                                            Use standard R syntax &mdash; define named functions, load libraries, or set global options.
-                                            To access run data (survey results, <code>survey_unit_sessions</code>, etc.), pass them as arguments &mdash;
-                                            functions cannot directly see variables defined in inline R code.
+                                            Define custom R functions and global variables here. They are injected before every R evaluation
+                                            in this run (showif, value, feedback, <code>relative_to</code>, branch conditions,
+                                            external URLs, email body, etc.) so you can call them by name. Use standard R syntax &mdash;
+                                            named functions, library calls, or global options.
+                                            To access run data (survey results, <code>survey_unit_sessions</code>, etc.), pass them
+                                            as arguments &mdash; functions cannot directly see variables defined in inline R code.
+                                        </p>
+                                        <p class="text-info">
+                                            <i class="fa fa-lock"></i> <strong>Secrets:</strong> Define sensitive values (API keys, tokens, passwords)
+                                            as string literals with a <code>secret_</code> prefix. They are <strong>automatically redacted</strong>
+                                            from all logs, debug output, error messages, run exports, and API responses. The value
+                                            must be a plain string literal (no expressions) and at least 6 characters.
                                         </p>
                                         <div class="row">
                                             <div class="col-md-12">
                                                 <div class="form-group">
-                                                    <textarea data-editor="r" placeholder="# Define your custom R functions here
+                                                    <textarea data-editor="r" placeholder="# Custom R functions &mdash; callable by name in showif, value, feedback, etc.
 my_score <- function(data) {
     mean(data, na.rm = TRUE)
-}" name="custom_r" rows="20" cols="80" class="big_ace_editor form-control"><?= h($run->getCustomRFunctions()); ?></textarea>
+}
+
+# Secrets &mdash; auto-redacted from logs, errors, exports, and API responses
+secret_api_key <- &quot;sk-proj-xxxxxxxxxxxx&quot;
+secret_db_pass  &lt;- &quot;hunter2&quot;" name="custom_r" rows="20" cols="80" class="big_ace_editor form-control"><?= h($run->getCustomRFunctions()); ?></textarea>
                                                 </div>
                                             </div>
                                         </div>

--- a/templates/admin/run/settings.php
+++ b/templates/admin/run/settings.php
@@ -741,12 +741,12 @@ qplot(survey_name$created) # plot entries by startdate</code></pre></li>
 
             var saveHtml = await saveRes.text();
             if (saveHtml) {
-                var heading = document.getElementById('app_heading');
-                if (heading) {
+                var pane = rForm.closest('.tab-pane');
+                if (pane) {
                     var tmp = document.createElement('div');
                     tmp.innerHTML = saveHtml;
                     while (tmp.firstChild) {
-                        heading.parentNode.insertBefore(tmp.firstChild, heading.nextSibling);
+                        pane.insertBefore(tmp.firstChild, pane.firstChild);
                     }
                 }
             }

--- a/templates/admin/run/settings.php
+++ b/templates/admin/run/settings.php
@@ -276,8 +276,8 @@ my_score <- function(data) {
                                                     <?php foreach ($run->getSecrets() as $name => $value): ?>
                                                     <tr>
                                                         <td><code>secret_<?= h($name) ?></code></td>
-                                                        <td><input type="hidden" class="secret-name-hidden" value="<?= h($name) ?>"><div class="secret-value-wrap"><input type="text" class="form-control input-sm secret-value secret-masked" value="<?= h($value) ?>"><button type="button" class="secret-toggle" title="Toggle visibility"><i class="fa fa-eye"></i></button></div></td>
-                                                        <td><button type="button" class="btn btn-danger btn-xs delete-secret" title="Delete secret"><i class="fa fa-trash"></i></button></td>
+                                                        <td><input type="hidden" class="secret-name-hidden" value="<?= h($name) ?>"><div class="secret-value-wrap"><input type="text" class="form-control input-sm secret-value secret-masked" value="<?= h($value) ?>"><button type="button" class="secret-toggle" data-toggle="tooltip" title="Toggle visibility"><i class="fa fa-eye"></i></button></div></td>
+                                                        <td><button type="button" class="btn btn-danger btn-xs delete-secret" data-toggle="tooltip" title="Delete secret"><i class="fa fa-trash"></i></button></td>
                                                     </tr>
                                                     <?php endforeach; ?>
                                                 </tbody>
@@ -565,6 +565,8 @@ qplot(survey_name$created) # plot entries by startdate</code></pre></li>
     var saveIndicator = document.getElementById('secrets-save-indicator');
     var alertsContainer = document.getElementById('secrets-alerts');
 
+    jQuery('[data-toggle="tooltip"]').tooltip();
+
     function collectSecrets() {
         var secrets = {};
         var rows = tbody.querySelectorAll('tr');
@@ -634,6 +636,7 @@ qplot(survey_name$created) # plot entries by startdate</code></pre></li>
         // Delete secret row + auto-save
         var del = e.target.closest('.delete-secret');
         if (del) {
+            jQuery(del).tooltip('destroy');
             del.closest('tr').remove();
             saveSecrets();
         }
@@ -666,9 +669,10 @@ qplot(survey_name$created) # plot entries by startdate</code></pre></li>
         var tr = document.createElement('tr');
         tr.innerHTML =
             '<td><code>secret_' + safeName + '</code></td>' +
-            '<td><input type="hidden" class="secret-name-hidden" value="' + safeName + '"><div class="secret-value-wrap"><input type="text" class="form-control input-sm secret-value secret-masked" value="' + safeValue + '"><button type="button" class="secret-toggle" title="Toggle visibility"><i class="fa fa-eye"></i></button></div></td>' +
-            '<td><button type="button" class="btn btn-danger btn-xs delete-secret" title="Delete secret"><i class="fa fa-trash"></i></button></td>';
+            '<td><input type="hidden" class="secret-name-hidden" value="' + safeName + '"><div class="secret-value-wrap"><input type="text" class="form-control input-sm secret-value secret-masked" value="' + safeValue + '"><button type="button" class="secret-toggle" data-toggle="tooltip" title="Toggle visibility"><i class="fa fa-eye"></i></button></div></td>' +
+            '<td><button type="button" class="btn btn-danger btn-xs delete-secret" data-toggle="tooltip" title="Delete secret"><i class="fa fa-trash"></i></button></td>';
         tbody.appendChild(tr);
+        jQuery(tr).find('[data-toggle="tooltip"]').tooltip();
 
         nameInput.value = '';
         valueInput.value = '';

--- a/templates/admin/run/settings.php
+++ b/templates/admin/run/settings.php
@@ -26,7 +26,8 @@
                                 <li><a href="#privacy" data-toggle="tab" aria-expanded="false">Privacy</a></li>
                                 <li><a href="#css" data-toggle="tab" aria-expanded="false">CSS</a></li>
                                 <li><a href="#js" data-toggle="tab" aria-expanded="false">JS</a></li>
-                                <li><a href="#r-functions-secrets" data-toggle="tab" aria-expanded="false">R Functions &amp; Secrets</a></li>
+                                <li><a href="#r-functions" data-toggle="tab" aria-expanded="false">R Functions</a></li>
+                                <li><a href="#secrets" data-toggle="tab" aria-expanded="false">R Secrets</a></li>
                                 <li><a href="#manifest" data-toggle="tab" aria-expanded="false">App</a></li>
                                 <li><a href="#service_message" data-toggle="tab" aria-expanded="false">Service message</a></li>
                                 <li><a href="#reminder" data-toggle="tab" aria-expanded="false">Reminder</a></li>
@@ -220,12 +221,12 @@
                                     </form>
                                 </div>
                                 <!-- /.tab-pane -->
-                                <div class="tab-pane" id="r-functions-secrets">
+                                <div class="tab-pane" id="r-functions">
                                     <form enctype="multipart/form-data" method="post" action="<?php echo admin_run_url($run->name, 'ajax_save_settings'); ?>">
                                         <p class="pull-right">
                                             <input type="submit" name="submit_settings" value="Save" class="btn btn-primary save_settings">
                                         </p>
-                                        <h4 class="lead"><i class="fa fa-cog"></i> R Functions &amp; Secrets</h4>
+                                        <h4 class="lead"><i class="fa fa-cog"></i> R Functions</h4>
                                         <p>
                                             Define custom R functions and global variables here. They are injected before every R evaluation
                                             in this run (showif, value, feedback, <code>relative_to</code>, branch conditions,
@@ -234,27 +235,62 @@
                                             To access run data (survey results, <code>survey_unit_sessions</code>, etc.), pass them
                                             as arguments &mdash; functions cannot directly see variables defined in inline R code.
                                         </p>
-                                        <p class="text-info">
-                                            <i class="fa fa-lock"></i> <strong>Secrets:</strong> Define sensitive values (API keys, tokens, passwords)
-                                            as string literals with a <code>secret_</code> prefix. They are <strong>automatically redacted</strong>
-                                            from all logs, debug output, error messages, run exports, and API responses. The value
-                                            must be a plain string literal (no expressions) and at least 6 characters.
-                                        </p>
                                         <div class="row">
                                             <div class="col-md-12">
                                                 <div class="form-group">
                                                     <textarea data-editor="r" placeholder="# Custom R functions &mdash; callable by name in showif, value, feedback, etc.
 my_score <- function(data) {
     mean(data, na.rm = TRUE)
-}
-
-# Secrets &mdash; auto-redacted from logs, errors, exports, and API responses
-secret_api_key <- &quot;sk-proj-xxxxxxxxxxxx&quot;
-secret_db_pass  &lt;- &quot;hunter2&quot;" name="custom_r" rows="20" cols="80" class="big_ace_editor form-control"><?= h($run->getCustomRFunctions()); ?></textarea>
+}" name="custom_r" rows="20" cols="80" class="big_ace_editor form-control"><?= h($run->getCustomRFunctions()); ?></textarea>
                                                 </div>
                                             </div>
                                         </div>
                                     </form>
+                                </div>
+                                <!-- /.tab-pane -->
+                                <div class="tab-pane" id="secrets">
+                                    <div id="secrets-alerts"></div>
+                                    <h4 class="lead"><i class="fa fa-lock"></i> Secrets</h4>
+                                    <p>
+                                        Define sensitive values (API keys, tokens, passwords) here. They are <strong>encrypted at rest</strong>
+                                        in the database and <strong>automatically redacted</strong> from all logs, debug output, error messages,
+                                        run exports, and API responses. Changes are saved immediately.
+                                    </p>
+                                    <p>
+                                        In your R code (showif, value, feedback, etc.), access secrets as
+                                        <code>.formr$secret_&lt;name&gt;</code> &mdash; for example, a secret named
+                                        <code>api_key</code> is available as <code>.formr$secret_api_key</code>.
+                                    </p>
+                                    <div id="secrets-save-indicator" class="text-muted" style="visibility: hidden; height: 22px; margin-bottom: 10px;"><i class="fa fa-spinner fa-spin"></i> Saving...</div>
+                                    <div class="row">
+                                        <div class="col-md-12">
+                                            <table class="table table-striped" id="secrets-table">
+                                                <thead>
+                                                    <tr>
+                                                        <th>Name</th>
+                                                        <th>Value</th>
+                                                        <th></th>
+                                                    </tr>
+                                                </thead>
+                                                    <tbody id="secrets-tbody">
+                                                    <?php foreach ($run->getSecrets() as $name => $value): ?>
+                                                    <tr>
+                                                        <td><code>secret_<?= h($name) ?></code></td>
+                                                        <td><input type="hidden" class="secret-name-hidden" value="<?= h($name) ?>"><div class="secret-value-wrap"><input type="text" class="form-control input-sm secret-value secret-masked" value="<?= h($value) ?>"><button type="button" class="secret-toggle" title="Toggle visibility"><i class="fa fa-eye"></i></button></div></td>
+                                                        <td><button type="button" class="btn btn-danger btn-xs delete-secret" title="Delete secret"><i class="fa fa-trash"></i></button></td>
+                                                    </tr>
+                                                    <?php endforeach; ?>
+                                                </tbody>
+                                                <tfoot>
+                                                    <tr>
+                                                        <td><input type="text" id="new-secret-name" class="form-control input-sm" placeholder="e.g. api_key"></td>
+                                                        <td><input type="text" id="new-secret-value" class="form-control input-sm" placeholder="Secret value"></td>
+                                                        <td><button type="button" id="add-secret-btn" class="btn btn-primary btn-xs"><i class="fa fa-plus"></i></button></td>
+                                                    </tr>
+                                                </tfoot>
+                                            </table>
+                                        </div>
+                                    </div>
                                 </div>
                                 <!-- /.tab-pane -->
                                 <div class="tab-pane" id="manifest">
@@ -481,6 +517,165 @@ qplot(survey_name$created) # plot entries by startdate</code></pre></li>
     <!-- /.content -->
 </div>
 
+<style>
+.secret-value-wrap {
+    display: flex;
+    align-items: center;
+    position: relative;
+}
+.secret-value-wrap .secret-value {
+    flex: 1;
+    padding-right: 30px;
+}
+.secret-value-wrap .secret-toggle {
+    position: absolute;
+    right: 4px;
+    background: none;
+    border: none;
+    cursor: pointer;
+    color: #999;
+    padding: 4px 6px;
+}
+.secret-value-wrap .secret-toggle:hover {
+    color: #333;
+}
+.secret-masked {
+    -webkit-text-security: disc;
+}
+#secrets-table td {
+    vertical-align: middle;
+}
+#secrets-table tfoot td {
+    border-top: 2px solid #ddd;
+}
+#secrets-table tfoot td:first-child {
+    width: 35%;
+}
+#secrets-table tfoot td:nth-child(2) {
+    width: 50%;
+}
+#secrets-table tfoot td:last-child {
+    width: 15%;
+}
+</style>
+<script>
+(function() {
+    var tbody = document.getElementById('secrets-tbody');
+    var saveUrl = '<?php echo admin_run_url($run->name, 'ajax_save_settings'); ?>';
+    var saveIndicator = document.getElementById('secrets-save-indicator');
+    var alertsContainer = document.getElementById('secrets-alerts');
+
+    function collectSecrets() {
+        var secrets = {};
+        var rows = tbody.querySelectorAll('tr');
+        rows.forEach(function(row) {
+            var nameInput = row.querySelector('.secret-name-hidden');
+            var valueInput = row.querySelector('.secret-value');
+            if (nameInput && valueInput) {
+                var name = nameInput.value.trim();
+                if (name) {
+                    secrets[name] = valueInput.value;
+                }
+            }
+        });
+        return secrets;
+    }
+
+    function hasName(name) {
+        var rows = tbody.querySelectorAll('tr');
+        var found = false;
+        rows.forEach(function(row) {
+            var input = row.querySelector('.secret-name-hidden');
+            if (input && input.value.trim() === name) {
+                found = true;
+            }
+        });
+        return found;
+    }
+
+    function saveSecrets() {
+        var secrets = collectSecrets();
+        saveIndicator.style.visibility = 'visible';
+
+        var formData = new FormData();
+        formData.append('secrets_json', JSON.stringify(secrets));
+
+        fetch(saveUrl, { method: 'POST', body: formData, headers: { 'X-Requested-With': 'XMLHttpRequest' } })
+            .then(function(r) { return r.text(); })
+            .then(function(html) {
+                saveIndicator.innerHTML = '<i class="fa fa-check"></i> Saved';
+                if (html.indexOf('alert-danger') !== -1) {
+                    alertsContainer.innerHTML = html;
+                }
+                setTimeout(function() {
+                    saveIndicator.innerHTML = '<i class="fa fa-spinner fa-spin"></i> Saving...';
+                    saveIndicator.style.visibility = 'hidden';
+                }, 1200);
+            })
+            .catch(function() {
+                saveIndicator.style.visibility = 'hidden';
+                alertsContainer.innerHTML = '<div class="alert alert-danger">Failed to save secrets.</div>';
+            });
+    }
+
+    // Toggle secret visibility via eye button
+    tbody.addEventListener('click', function(e) {
+        var btn = e.target.closest('.secret-toggle');
+        if (btn) {
+            var wrap = btn.closest('.secret-value-wrap');
+            if (!wrap) return;
+            var input = wrap.querySelector('.secret-value');
+            if (!input) return;
+            input.classList.toggle('secret-masked');
+            btn.querySelector('i').className = input.classList.contains('secret-masked') ? 'fa fa-eye' : 'fa fa-eye-slash';
+            return;
+        }
+
+        // Delete secret row + auto-save
+        var del = e.target.closest('.delete-secret');
+        if (del) {
+            del.closest('tr').remove();
+            saveSecrets();
+        }
+    });
+
+    // Auto-save on value change (blur)
+    tbody.addEventListener('blur', function(e) {
+        var input = e.target.closest('.secret-value');
+        if (input) {
+            saveSecrets();
+        }
+    }, true);
+
+    // Add new secret + auto-save
+    document.getElementById('add-secret-btn').addEventListener('click', function() {
+        var nameInput = document.getElementById('new-secret-name');
+        var valueInput = document.getElementById('new-secret-value');
+        var name = nameInput.value.trim();
+        var value = valueInput.value.trim();
+
+        if (!name) { alert('Please enter a secret name.'); return; }
+        if (!value) { alert('Please enter a secret value.'); return; }
+        if (hasName(name)) {
+            alert('A secret with this name already exists.');
+            return;
+        }
+
+        var safeName = name.replace(/[<>&"']/g, '');
+        var safeValue = value.replace(/[<>&"']/g, '');
+        var tr = document.createElement('tr');
+        tr.innerHTML =
+            '<td><code>secret_' + safeName + '</code></td>' +
+            '<td><input type="hidden" class="secret-name-hidden" value="' + safeName + '"><div class="secret-value-wrap"><input type="text" class="form-control input-sm secret-value secret-masked" value="' + safeValue + '"><button type="button" class="secret-toggle" title="Toggle visibility"><i class="fa fa-eye"></i></button></div></td>' +
+            '<td><button type="button" class="btn btn-danger btn-xs delete-secret" title="Delete secret"><i class="fa fa-trash"></i></button></td>';
+        tbody.appendChild(tr);
+
+        nameInput.value = '';
+        valueInput.value = '';
+        saveSecrets();
+    });
+})();
+</script>
 <?php
 Template::loadChild('admin/run/run_modals', array('reminders' => array()));
 Template::loadChild('admin/footer');

--- a/templates/admin/run/settings.php
+++ b/templates/admin/run/settings.php
@@ -231,6 +231,8 @@
                                             (showif, value, feedback, <code>relative_to</code>, branch conditions, external URLs, email body, etc.).
                                             Functions are injected before your inline R code so you can call them by name.
                                             Use standard R syntax &mdash; define named functions, load libraries, or set global options.
+                                            To access run data (survey results, <code>survey_unit_sessions</code>, etc.), pass them as arguments &mdash;
+                                            functions cannot directly see variables defined in inline R code.
                                         </p>
                                         <div class="row">
                                             <div class="col-md-12">

--- a/webroot/assets/common/js/run_settings.js
+++ b/webroot/assets/common/js/run_settings.js
@@ -60,7 +60,7 @@ import { ajaxErrorHandling, bootstrap_alert } from './main.js';
                 method: 'POST'
             }).done(function (data) {
                 if (data !== '')
-                    $(data).insertAfter($("#app_heading"));
+                    $(data).prependTo(form.closest('.tab-pane'));
                 $(elm).prop("disabled", true);
             }).fail(function (e, x, settings, exception) {
                 ajaxErrorHandling(e, x, settings, exception);


### PR DESCRIPTION
This PR adds two major capabilities to the run settings admin UI — Custom R Code and Secrets — plus a syntax validation helper to catch errors early - I tried to follow our design discussion as close as possble, although I added some additional QoL features in the admin UI, please review and share your thoughts!

**Custom R Code**
R code authored in the new "R Functions" tab of the run settings page is saved to a per-run file (analogous to custom CSS/JS) and loaded on every OpenCPU evaluation within that run. This lets researchers define reusable helpers, computed variables, or ggplot themes that apply across all surveys in a study without repeating inline code.
Internally, the code is wrapped in eval(parse(text=...)) before being passed to OpenCPU, which avoids the parser choking on function() definitions, and is placed outside the IIFE so functions persist across calls. The custom_r column was added to survey_runs; the storage path mirrors the existing custom CSS/JS pattern.

-> **Question**: Should we get clever here (like with secrets or run_data or API) about injecting only requested functions or values? Con: We could miss edgecases with regex or strpos...

**Secrets**
Encrypted run-level secrets are stored in a new survey_run_secrets table (AES-256 via formr's Crypto service). They are injected into the R session as a named list (.formr$secrets_$NAME) on every OpenCPU call, and any occurrence of a secret value in output is automatically redacted. The admin UI in the Run Settings page provides an add/delete table with inline auto-save on each change, keyboard-friendly (Enter to add, focus return). Secrets remain decrypted only in memory during the request — the DB column stores ciphertext only.

**R Syntax Validation (non-blocking, users can allways save!)**
A "Save & Test R Syntax" button replaces the plain Save button in the R Functions tab. It saves the form first (always succeeds — never blocks on invalid code), then calls base::parse() via OpenCPU to check syntax. Errors are displayed above the editor in a block that preserves R's multi-line caret format. A "Copy for LLM" button appears on parse failures, copying a structured TASK: … CODE: … ERROR: … block to the clipboard for pasting into an LLM prompt. I think this nessessary because the custom R code is shared between all Opencpu Run sessions, which could be confusing when debugging specific R Code chuncs (think: "Oh no, nothing is working anymore" :) )

Additional changes:
- Changed result_log column from TEXT to MEDIUMTEXT to prevent overflow with long custom R code.
- Fixed Bootstrap tooltip lingering on R Secrets delete button.
- Reduced textarea row heights for description/footer/blurb; increased for custom CSS/JS/R Functions.
- Secrets doc updates describing encryption, access patterns, and usage.

New files:
- Model/RunSecret.php — encrypted secret model with CRUD
- sql/patches/057_custom_r_path.sql — custom_r column + file path
- sql/patches/058_result_log_mediumtext.sql
- sql/patches/059_create_run_secrets.sql — survey_run_secrets table

Schema changes:
- survey_runs — added custom_r (TEXT), custom_r_path (VARCHAR(255))
- survey_run_secrets — new table (id, run_id, name, value, created/updated)