### PR TITLE
fix(SkipForward): add 'condition' to exportable attributes

### DIFF
--- a/application/Model/RunUnit/SkipForward.php
+++ b/application/Model/RunUnit/SkipForward.php
@@ -9,6 +9,6 @@ class SkipForward extends Branch {
      * An array of unit's exportable attributes
      * @var array
      */
-    public $export_attribs = array('type', 'description', 'position', 'special', 'automatically_jump', 'if_true', 'automatically_go_on');
+    public $export_attribs = array('type', 'description', 'position', 'special', 'condition', 'if_true', 'automatically_jump', 'automatically_go_on');
 
 }


### PR DESCRIPTION
### Problem

`SkipForward::$export_attribs` was missing `'condition'`, unlike `SkipBackward` which correctly includes it. Both classes extend `Branch` and store their condition in the `survey_branches.condition` column — the property exists at runtime, it's just not in the server-side export allowlist.

### Impact

Two different export code paths produce different results:

| Path | Mechanism | `condition` included? |
|------|-----------|----------------------|
| **UI Export** (run editor → "Export" button) | JS serializes browser DOM form inputs → `Run::export()` | **Yes** — `<textarea name="condition">` is in the DOM |
| **API** (`/api/v1/run-structure`) + "Export Run Structure" | `Run::exportStructure()` → `getExportUnit()` iterates `$export_attribs` as allowlist | **No** — `'condition'` was missing from the allowlist |

This means any SkipForward unit exported via the API or "Export Run Structure" silently loses its condition. Re-importing that JSON produces a SkipForward with a null/empty condition — it will either always fire or never fire, breaking study flow.

### Fix

Add `'condition'` to `SkipForward::$export_attribs`, matching what `SkipBackward` already declares.