### PR TITLE
Feature/internal api url

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/) and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [Unreleased]
+
+### Added
+- **Optional `api_internal_url` setting** for R→formr API calls from OpenCPU. When set (e.g. `http://formr_app/api` on the shared Docker network), `opencpu_prepare_api_access` injects it as `.formr$host` instead of the public `api_base_url()`, so `formr_api_*()` calls skip DNS, TLS, and the reverse proxy (~30% faster per call in benchmarks). Empty (the default) keeps the previous behaviour. The internal hostname must resolve to a vhost that serves the API; the bearer token travels as plaintext HTTP on this URL, so only enable it on a trusted single-host Docker network.
+
 ## [v1.0.0] - 16.05.2026
 
 ### Upgrade procedure — REQUIRED

--- a/application/Functions.php
+++ b/application/Functions.php
@@ -1213,8 +1213,9 @@ function opencpu_prepare_api_access($code, &$variables)
     // `host` in particular is a name widely used by httr/curl in user
     // code. The R-side helpers (formr_api_authenticate, formr_api_results)
     // read these from `.formr$` as their auto-pickup source.
+    $api_host = rtrim(Config::get('api_internal_url', ''), '/') ?: api_base_url();
     $access_token = "'" . addcslashes($token_data['access_token'], "'\\") . "'";
-    $host = "'" . addcslashes(rtrim(Config::get('api_internal_url'), '/') ?: api_base_url(), "'\\") . "'";
+    $host = "'" . addcslashes($api_host, "'\\") . "'";
     $run_name = "'" . addcslashes($run->name, "'\\") . "'";
 
     if (is_string($variables)) {

--- a/application/Functions.php
+++ b/application/Functions.php
@@ -1214,7 +1214,7 @@ function opencpu_prepare_api_access($code, &$variables)
     // code. The R-side helpers (formr_api_authenticate, formr_api_results)
     // read these from `.formr$` as their auto-pickup source.
     $access_token = "'" . addcslashes($token_data['access_token'], "'\\") . "'";
-    $host = "'" . addcslashes(Config::get('api_internal_url') ?: api_base_url(), "'\\") . "'";
+    $host = "'" . addcslashes(rtrim(Config::get('api_internal_url'), '/') ?: api_base_url(), "'\\") . "'";
     $run_name = "'" . addcslashes($run->name, "'\\") . "'";
 
     if (is_string($variables)) {

--- a/application/Functions.php
+++ b/application/Functions.php
@@ -1214,7 +1214,7 @@ function opencpu_prepare_api_access($code, &$variables)
     // code. The R-side helpers (formr_api_authenticate, formr_api_results)
     // read these from `.formr$` as their auto-pickup source.
     $access_token = "'" . addcslashes($token_data['access_token'], "'\\") . "'";
-    $host = "'" . addcslashes(api_base_url(), "'\\") . "'";
+    $host = "'" . addcslashes(Config::get('api_internal_url') ?: api_base_url(), "'\\") . "'";
     $run_name = "'" . addcslashes($run->name, "'\\") . "'";
 
     if (is_string($variables)) {

--- a/config-dist/settings.php
+++ b/config-dist/settings.php
@@ -44,6 +44,13 @@ $settings['alternative_opencpu_instance'] = array(
 	'r_lib_path' => '/usr/local/lib/R/site-library'
 );
 
+// Internal URL for R→formr API calls from OpenCPU (Docker bridge network).
+// When set, `.formr$host` uses this instead of the public `api_base_url()`,
+// avoiding DNS, TLS, and reverse-proxy overhead on every `formr_api_*()` call.
+// Example: 'http://formr_app/api' (same Docker network as opencpu).
+// Leave empty to fall back to `api_base_url()` (current behaviour).
+$settings['api_internal_url'] = '';
+
 // email SMTP and queueing configuration for emails sent by the formr app itself
 // for example for email confirmation and password reset
 $settings['email'] = array(

--- a/config-dist/settings.php
+++ b/config-dist/settings.php
@@ -49,6 +49,13 @@ $settings['alternative_opencpu_instance'] = array(
 // avoiding DNS, TLS, and reverse-proxy overhead on every `formr_api_*()` call.
 // Example: 'http://formr_app/api' (same Docker network as opencpu).
 // Leave empty to fall back to `api_base_url()` (current behaviour).
+// Requirements: the hostname must reach an Apache vhost that serves the API
+// (admin/API vhost, NOT the study vhost — an unmatched Host header falls
+// through to the *first* vhost, so make the routing explicit with a
+// ServerAlias for the internal hostname rather than relying on vhost order).
+// The OAuth bearer token travels as plaintext HTTP on this URL: only set it
+// on a trusted single-host Docker network. On multi-host/overlay networks,
+// encrypt the network or leave this empty.
 $settings['api_internal_url'] = '';
 
 // email SMTP and queueing configuration for emails sent by the formr app itself


### PR DESCRIPTION
Free Speed improvement by skipping DNS, TLS and Proxy when using the formr API in openCPU. Fallback is current behaviour.

Quick Benchmark for a api call (ca 30% faster):

Code:

```{r}
formr_api_authenticate()

n <- 100
elapsed <- numeric(n)
for (i in seq_len(n)) {
  t0 <- Sys.time()
  s <- formr_api_sessions(.formr$run_name, limit = 1)
  elapsed[i] <- as.numeric(difftime(Sys.time(), t0, units = "secs"))
}

cat(sprintf("Host: %s\n", .formr$host))
cat(sprintf("formr_api_sessions (n=%d):\n", n))
cat(sprintf("  avg: %.1f ms\n", mean(elapsed)*1000))
cat(sprintf("  min: %.1f ms\n", min(elapsed)*1000))
cat(sprintf("  max: %.1f ms\n", max(elapsed)*1000))
cat(sprintf("  p50: %.1f ms\n", median(elapsed)*1000))
```

Host: https://formr.rstudy.org/api
formr_api_sessions (n=100):
  avg: 63.9 ms
  min: 43.1 ms
  max: 176.1 ms
  p50: 58.9 ms

Host: http://formr_app/api
formr_api_sessions (n=100):
  avg: 43.8 ms
  min: 25.2 ms
  max: 163.2 ms
  p50: 38.5 ms