### PR TITLE
Fix/export attributes

### DIFF
--- a/application/Model/RunUnit/External.php
+++ b/application/Model/RunUnit/External.php
@@ -15,7 +15,7 @@ class External extends RunUnit {
      * An array of unit's exportable attributes
      * @var array
      */
-    public $export_attribs = array('type', 'description', 'position', 'special', 'address', 'api_end');
+    public $export_attribs = array('type', 'description', 'position', 'special', 'address', 'api_end', 'expire_after');
 
     public function __construct(Run $run, array $props = []) {
         parent::__construct($run, $props);

--- a/application/Model/RunUnit/Page.php
+++ b/application/Model/RunUnit/Page.php
@@ -10,7 +10,7 @@ class Page extends RunUnit {
      * An array of unit's exportable attributes
      * @var array
      */
-    public $export_attribs = array('type', 'description', 'position', 'special', 'body');
+    public $export_attribs = array('type', 'description', 'position', 'special', 'body', 'title');
 
     public function __construct(Run $run, array $props = []) {
         parent::__construct($run, $props);

--- a/application/Model/RunUnit/SkipBackward.php
+++ b/application/Model/RunUnit/SkipBackward.php
@@ -9,7 +9,7 @@ class SkipBackward extends Branch {
      * An array of unit's exportable attributes
      * @var array
      */
-    public $export_attribs = array('type', 'description', 'position', 'special', 'condition', 'if_true');
+    public $export_attribs = array('type', 'description', 'position', 'special', 'condition', 'if_true', 'automatically_jump', 'automatically_go_on');
 
     public function displayForRun($prepend = '') {
         

--- a/application/Model/RunUnit/SkipForward.php
+++ b/application/Model/RunUnit/SkipForward.php
@@ -9,6 +9,6 @@ class SkipForward extends Branch {
      * An array of unit's exportable attributes
      * @var array
      */
-    public $export_attribs = array('type', 'description', 'position', 'special', 'automatically_jump', 'if_true', 'automatically_go_on');
+    public $export_attribs = array('type', 'description', 'position', 'special', 'condition', 'if_true', 'automatically_jump', 'automatically_go_on');
 
 }


### PR DESCRIPTION
## Fix: missing exportable attributes on RunUnit models

The API export (run structure JSON) was dropping the `condition` attribute from `SkipForward`, and missing exportable attributes from `External`, `Page`, and `SkipBackward`.

- Adds `condition` to `SkipForward`'s exportable attributes
- Adds missing exportable attributes to `External`, `Page`, and `SkipBackward`