### PR TITLE
fix: participants who return in time are routed down the Wait's timeout branch

### DIFF
--- a/application/Model/RunSession.php
+++ b/application/Model/RunSession.php
@@ -531,7 +531,27 @@ class RunSession extends Model {
             $u = $row;
             $u['id'] = $u['unit_id'];
             $unit = RunUnitFactory::make($this->run, $u);
-            $this->currentUnitSession = new UnitSession($this, $unit, $row);
+            // Pass the PK and let load() hydrate from the DB rather than
+            // handing $row straight to the constructor. UnitSession's
+            // $options allowlist (ed56a95f) keeps only 'id'/'load', so a
+            // full row arrived with `created` and `expires` silently
+            // dropped and load() never ran — every participant web request
+            // at a parked Pause/Wait then ran with created = NULL and
+            // expires = NULL. That defeated both fast paths in
+            // Pause::getUnitSessionExpirationData() (the stored-expires
+            // early return at :120 and the local anchor at :128), pushing
+            // the wait anchor onto OpenCPU's
+            // tail(survey_unit_sessions$created, 1) — which resolves
+            // against an unordered data frame and can return a session
+            // minutes or days old. A stale anchor older than wait_minutes
+            // makes the Wait report expired the instant the participant
+            // returns, so it takes move_on instead of run_to = body. See
+            // documentation/agent_doc/wait_premature_expiry_bug.md and
+            // bin/test_wait_tail_anchor_probe.php.
+            $this->currentUnitSession = new UnitSession($this, $unit, [
+                'id' => $row['id'],
+                'load' => true,
+            ]);
             return $this->currentUnitSession;
         } else {
             return false;

--- a/application/Model/UnitSession.php
+++ b/application/Model/UnitSession.php
@@ -751,6 +751,22 @@ class UnitSession extends Model {
                 }
             }
 
+            // Every data frame handed to R must come back in a deterministic
+            // chronological order. Without an ORDER BY the optimizer is free
+            // to return rows grouped by unit_id (it drives from
+            // survey_run_units and does a per-unit ref lookup), so
+            // tail(survey_unit_sessions$created, 1) is not "the most recent
+            // unit session" but "the newest session of whichever unit sorts
+            // last". On a looping ESM run that anchor lags by minutes; on a
+            // multi-week diary it measured two weeks stale at 20k rows. That
+            // is what made Wait/Pause units with wait_minutes report expired
+            // the moment a participant returned. `created` is the semantic
+            // key (it is what tail() is asked for); `id` breaks ties, which
+            // are real because a cascade creates several unit sessions inside
+            // the same second. Cost is ~0.2 ms at 2.4k rows — the sort set is
+            // one participant's history, not the table.
+            $order = ' ORDER BY `survey_unit_sessions`.`created`, `survey_unit_sessions`.`id`';
+
             if (!in_array($results_table, get_db_non_session_tables())) {
                 $joins = "
 					LEFT JOIN `survey_unit_sessions` ON `$results_table`.session_id = `survey_unit_sessions`.id
@@ -765,13 +781,16 @@ class UnitSession extends Model {
                 $where .= " AND `survey_runs`.id = :run_id";
             } elseif ($results_table == 'survey_run_sessions') {
                 $joins = "";
+                // No survey_unit_sessions in scope to order by.
+                $order = '';
             } elseif ($results_table == 'survey_users') {
                 $joins = "LEFT JOIN `survey_run_sessions` ON `survey_users`.id = `survey_run_sessions`.user_id";
+                $order = '';
             }
 
             $select .= " FROM `$results_table` ";
 
-            $q = $select . $joins . $where . ";";
+            $q = $select . $joins . $where . $order . ";";
 
             $get_results = $this->db->prepare($q);
             if (($runSession->id === null || $runSession->isTestingStudy()) && !in_array($results_table, get_db_non_session_tables())) {

--- a/application/Model/UnitSession.php
+++ b/application/Model/UnitSession.php
@@ -209,7 +209,23 @@ class UnitSession extends Model {
         if (empty($expirationData['expires'])) {
             return false;
         } elseif(!empty($expirationData['end_session'])) {
+            // Pause/Wait assign end_session and expired the same value
+            // (Pause.php:250), and the array_merge above copied BOTH into
+            // execResults. Reaching this branch means the wait is over and
+            // the unit session should END — which is what the daemon's
+            // END-q path already records, as 'wait_ended'. Drop the merged
+            // `expired` flag, or RunSession::executeUnitSession() — which
+            // tests `expired` before `end_session` (:370) — calls expire()
+            // instead of end() and stamps a perfectly normal elapse as
+            // result='expired'. The branch taken is identical either way
+            // (move_on); only the recorded result differs, which is why
+            // this was invisible until the exports gained `result`.
+            //
+            // Scoped to Pause/Wait by construction: Survey and External
+            // never set end_session, and Branch never sets expired, so no
+            // other unit type can reach here with `expired` in play.
             $this->execResults['end_session'] = true;
+            unset($this->execResults['expired']);
             return false; // ended NOT expired
         } elseif ($expirationData['expires'] < time()) {
             return true;

--- a/bin/test_wait_cascade_probe.php
+++ b/bin/test_wait_cascade_probe.php
@@ -1,0 +1,88 @@
+#!/usr/bin/php
+<?php
+/**
+ * Reproduces the production cascade that ends with an unexpected Email:
+ * an elapsed Wait is picked up by the queue daemon, which ends it and
+ * moves on, cascading Wait(30) -> PushMessage(40) -> Wait(50). The
+ * question is what state Wait(50) — a 10-minute wait — lands in.
+ *
+ * Parks a throwaway participant at a given position with an already-past
+ * `expires` + queued=2, then runs the real UnitSessionQueue pass over it
+ * and dumps every unit session the cascade produced.
+ *
+ * Usage:
+ *   docker exec formr_app php bin/test_wait_cascade_probe.php [run_id] [start_position]
+ *   docker exec formr_app php bin/test_wait_cascade_probe.php 43 30
+ */
+require_once dirname(__FILE__) . '/../setup.php';
+
+$run_id   = (int) ($argv[1] ?? 43);
+$start_at = (int) ($argv[2] ?? 30);
+
+$db  = DB::getInstance();
+$run = new Run(null, $run_id);
+if (!$run->valid) { fwrite(STDERR, "run {$run_id} not valid\n"); exit(1); }
+
+$unit_id = $db->findValue('survey_run_units', ['run_id' => $run_id, 'position' => $start_at], 'unit_id');
+if (!$unit_id) { fwrite(STDERR, "no unit at position {$start_at}\n"); exit(1); }
+
+$key = 'CASCADE' . bin2hex(random_bytes(24));
+$db->insert('survey_users', ['user_code' => $key, 'created' => mysql_datetime(time())]);
+$user_id = $db->lastInsertId();
+$db->insert('survey_run_sessions', [
+    'run_id' => $run_id, 'session' => $key, 'user_id' => $user_id,
+    'position' => $start_at, 'created' => mysql_datetime(time()),
+]);
+$rs_id = $db->lastInsertId();
+
+// Park the participant on the start unit with an expiry already in the past,
+// exactly as the daemon would find it.
+$db->insert('survey_unit_sessions', [
+    'run_session_id' => $rs_id,
+    'unit_id'        => $unit_id,
+    'created'        => mysql_datetime(time() - 120),
+    'expires'        => mysql_datetime(time() - 60),
+    'queued'         => UnitSessionQueue::QUEUED_TO_END,
+]);
+$us_id = $db->lastInsertId();
+$db->update('survey_run_sessions', ['current_unit_session_id' => $us_id], ['id' => $rs_id]);
+
+echo "Parked participant {$key} at position {$start_at} (unit {$unit_id}, session {$us_id}).\n";
+echo "Running one UnitSessionQueue pass...\n\n";
+
+$config = array_merge(Config::get('unit_session'), ['queue_type' => 'UnitSession']);
+$queue  = new UnitSessionQueue($db, $config);
+$queue->runOnce();
+
+$rows = $db->execute(
+    'SELECT us.id, ru.position, u.type, us.created, us.expires, us.ended, us.expired,
+            us.queued, us.result
+       FROM survey_unit_sessions us
+       LEFT JOIN survey_units u      ON u.id = us.unit_id
+       LEFT JOIN survey_run_units ru ON ru.unit_id = us.unit_id
+      WHERE us.run_session_id = :rs
+      ORDER BY us.id ASC',
+    ['rs' => $rs_id]
+);
+
+printf("%-8s %-5s %-13s %-20s %-20s %-20s %-7s %s\n",
+    'id', 'pos', 'type', 'created', 'expires', 'ended/expired', 'queued', 'result');
+foreach ($rows as $r) {
+    $done = $r['ended'] ? $r['ended'] . ' (end)' : ($r['expired'] ? $r['expired'] . ' (EXP)' : '-');
+    printf("%-8s %-5s %-13s %-20s %-20s %-20s %-7s %s\n",
+        $r['id'], $r['position'], $r['type'], $r['created'],
+        $r['expires'] ?: '-', $done, $r['queued'], $r['result'] ?: '-');
+}
+
+$pos = $db->findValue('survey_run_sessions', ['id' => $rs_id], 'position');
+echo "\nRun session now at position {$pos}.\n";
+
+$emails = 0;
+foreach ($rows as $r) { if ($r['type'] === 'Email') { $emails++; } }
+echo $emails > 0
+    ? "\e[31mEMAIL UNIT REACHED ({$emails}) — reminder fired without the 10-minute wait elapsing.\e[0m\n"
+    : "\e[32mNo Email unit reached — cascade parked before the reminder, as designed.\e[0m\n";
+
+echo "\nKeeping rows for inspection. Clean up with:\n";
+echo "  DELETE FROM survey_run_sessions WHERE session = '{$key}';\n";
+echo "  DELETE FROM survey_users WHERE id = {$user_id};\n";

--- a/bin/test_wait_expired_leak_probe.php
+++ b/bin/test_wait_expired_leak_probe.php
@@ -70,8 +70,8 @@ $probe_rs = [];
  * @param mixed $expires value to pre-store in survey_unit_sessions.expires
  * @param bool  $cron    drive as the queue daemon rather than a web request
  */
-function scenario(string $label, int $run_id, int $unit_id, int $age, $expires, bool $cron, $blank = false) {
-    global $db, $run, $probe_rs;
+function scenario(string $label, int $run_id, int $unit_id, int $age, $expires, bool $cron, $blank = false, string $expect = null) {
+    global $db, $run, $probe_rs, $failures;
 
     // survey_run_sessions has UNIQUE KEY run_user (user_id, run_id), so
     // each scenario needs its own throwaway participant.
@@ -140,12 +140,19 @@ function scenario(string $label, int $run_id, int $unit_id, int $age, $expires, 
         var_export(peek($runUnit, 'relative_to_result'), true),
         var_export($res['check_failed'] ?? null, true),
         isset($res['expires']) ? var_export(mysql_datetime($res['expires']), true) : 'unset');
+    if ($expect !== null) {
+        $ok = ($after['result'] === $expect);
+        if (!$ok) { $failures++; }
+        printf("    %s expected result=%s\n", $ok ? "\e[32mPASS\e[0m" : "\e[31mFAIL\e[0m", var_export($expect, true));
+    }
     printf("    DB result=%-12s expires %s -> %s\n\n",
         var_export($after['result'], true),
         var_export($expires_before, true), var_export($after['expires'], true));
 
     return $after['result'];
 }
+
+$failures = 0;
 
 $wm   = (float) $db->findValue('survey_pauses', ['id' => $unit_id], 'wait_minutes');
 $secs = (int) ($wm * 60);
@@ -155,11 +162,14 @@ echo "== Wait unit {$unit_id}, wait_minutes = {$wm} (= {$secs}s) ==\n\n";
 // as the CORRECT value the parking pass would have written.
 $correct_expires = static fn(int $age) => mysql_datetime(time() - $age + $secs);
 
-scenario('G elapsed, correct stored expires, web',  $run_id, $unit_id, $secs + 30, $correct_expires($secs + 30), false);
-scenario('H elapsed, correct stored expires, cron', $run_id, $unit_id, $secs + 30, $correct_expires($secs + 30), true);
-scenario('I elapsed, no stored expires, web',       $run_id, $unit_id, $secs + 30, null, false);
+// A genuine elapse ends the unit session; it is not an expiry. The daemon's
+// END-q path has always recorded 'wait_ended' — these web-driven paths must
+// agree with it rather than stamping 'expired'.
+scenario('G elapsed, correct stored expires, web',  $run_id, $unit_id, $secs + 30, $correct_expires($secs + 30), false, false, 'wait_ended');
+scenario('H elapsed, correct stored expires, cron', $run_id, $unit_id, $secs + 30, $correct_expires($secs + 30), true,  false, 'wait_ended');
+scenario('I elapsed, no stored expires, web',       $run_id, $unit_id, $secs + 30, null, false, false, 'wait_ended');
 // Control: not elapsed, participant returns early. Should take run_to.
-scenario('J not elapsed, participant returns, web', $run_id, $unit_id, 5, $correct_expires(5), false);
+scenario('J not elapsed, participant returns, web', $run_id, $unit_id, 5, $correct_expires(5), false, false, 'wait_ended');
 
 // Fail-open: survey_pauses row did not load, so $conditions ends up empty
 // and Pause.php:247 declares the wait over. Note this path sets NO
@@ -180,3 +190,5 @@ foreach ($probe_rs as [$rs_id, $user_id]) {
     $db->exec('DELETE FROM survey_users WHERE id = :id', ['id' => $user_id]);
 }
 echo "(cleaned up " . count($probe_rs) . " probe run sessions)\n";
+echo $failures === 0 ? "\e[32mALL ASSERTED SCENARIOS PASS\e[0m\n" : "\e[31m{$failures} SCENARIO(S) FAILED\e[0m\n";
+exit($failures === 0 ? 0 : 1);

--- a/bin/test_wait_expired_leak_probe.php
+++ b/bin/test_wait_expired_leak_probe.php
@@ -1,0 +1,182 @@
+#!/usr/bin/php
+<?php
+/**
+ * Wait `expired`-leak probe.
+ *
+ * Complements bin/test_wait_expiry_probe.php, which only ever drives
+ * scenarios with age = 0 — i.e. it never lets the wait actually elapse,
+ * so it never exercises the branch that can call expire() at all.
+ *
+ * This probe asks a different question: WHEN getUnitSessionExpirationData()
+ * reports expired = true, what does the rest of the chain do with it?
+ *
+ * Claim under test:
+ *   UnitSession::isExpired() merges the whole $expirationData into
+ *   $execResults (UnitSession.php:198) BEFORE returning false via the
+ *   end_session branch (:211). So execResults keeps expired = true.
+ *   execute() then returns early on end_session (:176) WITHOUT ever
+ *   calling Wait::getUnitSessionOutput(). RunSession::executeUnitSession()
+ *   tests !empty($result['expired']) FIRST (:370) and calls expire(),
+ *   which writes result = 'expired' and leaves `expires` untouched.
+ *
+ * If true, the observed production signature (result = 'expired',
+ * advanced to the next position, `expires` column still correct) is
+ * produced by the ordinary elapse path, and the Wait's own three-way
+ * branch is never consulted.
+ *
+ * Usage:
+ *   docker exec formr_app php /formr/bin/test_wait_expired_leak_probe.php <run_id> <unit_id>
+ *   docker exec formr_app php /formr/bin/test_wait_expired_leak_probe.php 43 707
+ */
+require_once dirname(__FILE__) . '/../setup.php';
+
+$run_id  = (int) ($argv[1] ?? 43);
+$unit_id = (int) ($argv[2] ?? 707);
+
+$db = DB::getInstance();
+
+function peek($obj, string $prop) {
+    $r = new ReflectionObject($obj);
+    while ($r && !$r->hasProperty($prop)) { $r = $r->getParentClass(); }
+    if (!$r) { return '<none>'; }
+    $p = $r->getProperty($prop); $p->setAccessible(true);
+    return $p->getValue($obj);
+}
+
+/** A Wait that records whether getUnitSessionOutput() was reached. */
+class ProbeWait extends Wait {
+    public $outputCalled = false;
+    public $outputReturned = null;
+    /** Simulate Pause::__construct's findRow('survey_pauses') coming back empty. */
+    public $blankPauseRow = false;
+    public function getUnitSessionOutput(UnitSession $unitSession) {
+        $this->outputCalled = true;
+        return $this->outputReturned = parent::getUnitSessionOutput($unitSession);
+    }
+    public function blankPauseRow() {
+        $this->blankPauseRow = true;
+        $this->wait_minutes = $this->relative_to = $this->wait_until_time = $this->wait_until_date = null;
+        return $this;
+    }
+}
+
+$run = new Run(null, $run_id);
+if (!$run->valid) { fwrite(STDERR, "run {$run_id} not valid\n"); exit(1); }
+
+$probe_rs = [];
+
+/**
+ * @param int   $age     backdate the unit session `created` by N seconds
+ * @param mixed $expires value to pre-store in survey_unit_sessions.expires
+ * @param bool  $cron    drive as the queue daemon rather than a web request
+ */
+function scenario(string $label, int $run_id, int $unit_id, int $age, $expires, bool $cron, $blank = false) {
+    global $db, $run, $probe_rs;
+
+    // survey_run_sessions has UNIQUE KEY run_user (user_id, run_id), so
+    // each scenario needs its own throwaway participant.
+    $key = 'PROBE' . bin2hex(random_bytes(26));
+    $db->insert('survey_users', ['user_code' => $key, 'created' => mysql_datetime(time())]);
+    $user_id = $db->lastInsertId();
+
+    $db->insert('survey_run_sessions', [
+        'run_id' => $run_id, 'session' => $key, 'user_id' => $user_id,
+        'position' => 50, 'created' => mysql_datetime(time()),
+    ]);
+    $rs_id = $db->lastInsertId();
+    $probe_rs[] = [$rs_id, $user_id];
+
+    $row = [
+        'run_session_id' => $rs_id,
+        'unit_id'        => $unit_id,
+        'created'        => mysql_datetime(time() - $age),
+    ];
+    if ($expires !== null) { $row['expires'] = $expires; $row['queued'] = 2; }
+    $db->insert('survey_unit_sessions', $row);
+    $us_id = $db->lastInsertId();
+
+    $runSession = new RunSession($key, $run);
+    $runSession->user->cron = $cron;
+    $runUnit = new ProbeWait($run, ['id' => $unit_id]);
+    if ($blank === true) { $runUnit->blankPauseRow(); }
+    if ($blank === 'gcus') {
+        // Hydrate exactly the way RunSession::getCurrentUnitSession():534
+        // does: hand the constructor a full DB row, with no 'load' key.
+        $unitSession = new UnitSession($runSession, $runUnit, $db->findRow(
+            'survey_unit_sessions', ['id' => $us_id],
+            'id, unit_id, run_session_id, created, expires, ended, expired'
+        ));
+    } else {
+        $unitSession = new UnitSession($runSession, $runUnit, ['id' => $us_id, 'load' => true]);
+    }
+    printf("%-42s hydrated: created=%s expires=%s\n", '', var_export($unitSession->created, true),
+        var_export($unitSession->expires, true));
+
+    $expires_before = $db->findValue('survey_unit_sessions', ['id' => $us_id], 'expires');
+
+    $res = $unitSession->execute();
+
+    // Replay what RunSession::executeUnitSession() would do with $res,
+    // in its real order (expired -> end_session -> queue).
+    $verdict = 'other';
+    if (!empty($res['expired']))          { $unitSession->expire(); $verdict = 'expire()'; }
+    elseif (!empty($res['end_session']))  { $unitSession->end();    $verdict = 'end()'; }
+    elseif (isset($res['queue']))         { $verdict = 'queue()'; }
+
+    $branch = isset($res['run_to']) ? 'run_to = ' . var_export($res['run_to'], true)
+            : (!empty($res['move_on'])   ? 'move_on (next position)'
+            : (!empty($res['wait_user']) ? 'wait_user (stay put)' : 'none'));
+
+    $after = $db->findRow('survey_unit_sessions', ['id' => $us_id], 'result, expires, expired, ended');
+
+    printf("%-42s age=%-6s cron=%-5s\n", $label, $age . 's', var_export($cron, true));
+    printf("    execResults: expired=%-5s end_session=%-5s -> %s via %s\n",
+        var_export($res['expired'] ?? null, true),
+        var_export($res['end_session'] ?? null, true), $branch, $verdict);
+    printf("    Wait::getUnitSessionOutput() called? %s%s\e[0m\n",
+        $runUnit->outputCalled ? '' : "\e[31m", $runUnit->outputCalled ? 'yes' : 'NO - branch never consulted');
+    printf("    anchor: relative_to=%s resolved=%s | check_failed=%s computed_expires=%s\n",
+        var_export(peek($runUnit, 'relative_to'), true),
+        var_export(peek($runUnit, 'relative_to_result'), true),
+        var_export($res['check_failed'] ?? null, true),
+        isset($res['expires']) ? var_export(mysql_datetime($res['expires']), true) : 'unset');
+    printf("    DB result=%-12s expires %s -> %s\n\n",
+        var_export($after['result'], true),
+        var_export($expires_before, true), var_export($after['expires'], true));
+
+    return $after['result'];
+}
+
+$wm   = (float) $db->findValue('survey_pauses', ['id' => $unit_id], 'wait_minutes');
+$secs = (int) ($wm * 60);
+echo "== Wait unit {$unit_id}, wait_minutes = {$wm} (= {$secs}s) ==\n\n";
+
+// Elapsed cases: `created` backdated past the deadline, `expires` stored
+// as the CORRECT value the parking pass would have written.
+$correct_expires = static fn(int $age) => mysql_datetime(time() - $age + $secs);
+
+scenario('G elapsed, correct stored expires, web',  $run_id, $unit_id, $secs + 30, $correct_expires($secs + 30), false);
+scenario('H elapsed, correct stored expires, cron', $run_id, $unit_id, $secs + 30, $correct_expires($secs + 30), true);
+scenario('I elapsed, no stored expires, web',       $run_id, $unit_id, $secs + 30, null, false);
+// Control: not elapsed, participant returns early. Should take run_to.
+scenario('J not elapsed, participant returns, web', $run_id, $unit_id, 5, $correct_expires(5), false);
+
+// Fail-open: survey_pauses row did not load, so $conditions ends up empty
+// and Pause.php:247 declares the wait over. Note this path sets NO
+// 'expires' key, so the DB column keeps the correct parked value.
+scenario('K blank pauses row, stored expires, web',  $run_id, $unit_id, 1, $correct_expires(1), false, true);
+scenario('L blank pauses row, no stored expires',    $run_id, $unit_id, 1, null, false, true);
+
+// The real web path: RunSession::getCurrentUnitSession() hands the
+// constructor a full DB row, but the $options allowlist keeps only
+// 'id' and no 'load' key is present, so load() never runs. created and
+// expires arrive NULL even though the DB row has correct values.
+scenario('M participant returns, hydrated as web',   $run_id, $unit_id, 1, $correct_expires(1), false, 'gcus');
+scenario('N participant returns 13s in, as web',     $run_id, $unit_id, 13, $correct_expires(13), false, 'gcus');
+
+foreach ($probe_rs as [$rs_id, $user_id]) {
+    $db->exec('DELETE FROM survey_unit_sessions WHERE run_session_id = :id', ['id' => $rs_id]);
+    $db->exec('DELETE FROM survey_run_sessions WHERE id = :id', ['id' => $rs_id]);
+    $db->exec('DELETE FROM survey_users WHERE id = :id', ['id' => $user_id]);
+}
+echo "(cleaned up " . count($probe_rs) . " probe run sessions)\n";

--- a/bin/test_wait_expiry_probe.php
+++ b/bin/test_wait_expiry_probe.php
@@ -1,0 +1,115 @@
+#!/usr/bin/php
+<?php
+/**
+ * Wait-unit expiry probe. Investigates why a Wait with wait_minutes = N
+ * can report `expired` within a second of the unit session being created
+ * (observed on an ESM run: a 10-minute Wait at position 50 expiring in
+ * 0-1 s, which then walks the run into the Email reminder at position 60).
+ *
+ * Drives UnitSession::execute() through the scenarios the real cascade
+ * produces and reports which branch each one takes.
+ *
+ * Usage:
+ *   docker exec formr_app php bin/test_wait_expiry_probe.php <run_id> <unit_id>
+ *   docker exec formr_app php bin/test_wait_expiry_probe.php 43 707
+ */
+require_once dirname(__FILE__) . '/../setup.php';
+
+$run_id  = (int) ($argv[1] ?? 43);
+$unit_id = (int) ($argv[2] ?? 707);
+
+$db = DB::getInstance();
+
+function peek($obj, string $prop) {
+    $r = new ReflectionObject($obj);
+    while ($r && !$r->hasProperty($prop)) { $r = $r->getParentClass(); }
+    if (!$r) { return '<none>'; }
+    $p = $r->getProperty($prop); $p->setAccessible(true);
+    return $p->getValue($obj);
+}
+
+$run = new Run(null, $run_id);
+if (!$run->valid) { fwrite(STDERR, "run {$run_id} not valid\n"); exit(1); }
+
+$probe_rs = [];
+
+/**
+ * @param int    $age      backdate the unit session `created` by N seconds
+ * @param mixed  $expires  value to pre-store in survey_unit_sessions.expires
+ * @param bool   $cron     run as the queue daemon rather than a web request
+ */
+function scenario(string $label, int $run_id, int $unit_id, int $age, $expires, bool $cron) {
+    global $db, $run, $probe_rs;
+
+    // survey_run_sessions has UNIQUE KEY run_user (user_id, run_id), so each
+    // scenario needs its own throwaway participant.
+    $key = 'PROBE' . bin2hex(random_bytes(26));
+    $db->insert('survey_users', [
+        'user_code' => $key,
+        'created'   => mysql_datetime(time()),
+    ]);
+    $user_id = $db->lastInsertId();
+
+    $db->insert('survey_run_sessions', [
+        'run_id' => $run_id, 'session' => $key, 'user_id' => $user_id,
+        'position' => 50, 'created' => mysql_datetime(time()),
+    ]);
+    $rs_id = $db->lastInsertId();
+    $probe_rs[] = [$rs_id, $user_id];
+
+    $created = mysql_datetime(time() - $age);
+    $row = ['run_session_id' => $rs_id, 'unit_id' => $unit_id, 'created' => $created];
+    if ($expires !== null) { $row['expires'] = $expires; $row['queued'] = 2; }
+    $db->insert('survey_unit_sessions', $row);
+    $us_id = $db->lastInsertId();
+
+    $runSession = new RunSession($key, $run);
+    $runSession->user->cron = $cron;
+    $runUnit = RunUnitFactory::make($run, ['id' => $unit_id]);
+    $unitSession = new UnitSession($runSession, $runUnit, ['id' => $us_id, 'load' => true]);
+
+    try {
+        $res = $unitSession->execute();
+    } catch (Throwable $e) {
+        echo "{$label}: THREW " . get_class($e) . ': ' . $e->getMessage() . "\n";
+        echo '  at ' . $e->getFile() . ':' . $e->getLine() . "\n\n";
+        return false;
+    }
+
+    $branch = !empty($res['expired'])            ? "\e[31mEXPIRED -> move_on (next position)\e[0m"
+            : (isset($res['run_to'])             ? "run_to = " . var_export($res['run_to'], true)
+            : (!empty($res['wait_user'])         ? 'wait_user (stay put)'
+            : (!empty($res['end_session'])       ? 'end_session' : 'other')));
+
+    $exp = peek($runUnit, 'relative_to_result');
+    printf("%-46s age=%-5s stored_expires=%-21s cron=%-5s\n    -> %s\n",
+        $label, $age . 's', var_export($expires, true), var_export($cron, true), $branch);
+    printf("       relative_to=%s  resolved=%s  wait_minutes=%s\n\n",
+        var_export(peek($runUnit, 'relative_to'), true), var_export($exp, true),
+        var_export(peek($runUnit, 'wait_minutes'), true));
+
+    return !empty($res['expired']);
+}
+
+$wm = (float) $db->findValue('survey_pauses', ['id' => $unit_id], 'wait_minutes');
+echo "== Wait unit {$unit_id}, wait_minutes = {$wm} (= " . ($wm * 60) . "s) ==\n\n";
+
+$future = mysql_datetime(time() + (int) ($wm * 60));
+$past   = mysql_datetime(time() - 10);
+
+$bad = 0;
+$bad += scenario('A fresh, no stored expires, web',   $run_id, $unit_id, 0, null,    false);
+$bad += scenario('B fresh, no stored expires, cron',  $run_id, $unit_id, 0, null,    true);
+$bad += scenario('C stored expires in future, web',   $run_id, $unit_id, 0, $future, false);
+$bad += scenario('D stored expires in future, cron',  $run_id, $unit_id, 0, $future, true);
+$bad += scenario('E stored expires in PAST, web',     $run_id, $unit_id, 0, $past,   false);
+$bad += scenario('F stored expires in PAST, cron',    $run_id, $unit_id, 0, $past,   true);
+
+echo "Scenarios reporting EXPIRED while the wait had not elapsed: {$bad}\n";
+
+foreach ($probe_rs as [$rs_id, $user_id]) {
+    $db->exec('DELETE FROM survey_unit_sessions WHERE run_session_id = :id', ['id' => $rs_id]);
+    $db->exec('DELETE FROM survey_run_sessions WHERE id = :id', ['id' => $rs_id]);
+    $db->exec('DELETE FROM survey_users WHERE id = :id', ['id' => $user_id]);
+}
+echo "(cleaned up " . count($probe_rs) . " probe run sessions)\n";

--- a/bin/test_wait_tail_anchor_probe.php
+++ b/bin/test_wait_tail_anchor_probe.php
@@ -1,0 +1,162 @@
+#!/usr/bin/php
+<?php
+/**
+ * Wait stale-anchor probe — the root cause behind the premature-expiry bug.
+ *
+ * Two defects compound:
+ *
+ *  (1) RunSession::getCurrentUnitSession():534 hands `new UnitSession()` a
+ *      full DB row, but the constructor's $options allowlist (ed56a95f)
+ *      keeps only 'id', and the row carries no 'load' key, so load() never
+ *      runs. Every participant web request at a parked Wait therefore has
+ *      created = NULL and expires = NULL.
+ *
+ *      -> the fast path at Pause.php:120 (stored expires still in future)
+ *         cannot fire, and the fast path at Pause.php:128 (anchor =
+ *         $unitSession->created) cannot fire either. The anchor is resolved
+ *         through OpenCPU as tail(survey_unit_sessions$created, 1).
+ *
+ *  (2) The query backing that data frame (UnitSession.php:759-774) has NO
+ *      ORDER BY. MariaDB returns rows grouped by unit_id, so tail(...,1) is
+ *      not "the most recent unit session" — it is the newest session of
+ *      whichever unit_id sorts last. On run 43 that is unit 713, the
+ *      SkipBackward at position 110, which is only reached via the
+ *      position-100 branch. A participant looping through 80/90 leaves it
+ *      to go stale while they keep cycling.
+ *
+ * When that stale anchor is older than wait_minutes, the Wait is declared
+ * expired the instant the participant returns. expire() never writes
+ * `expires`, so the column keeps the correct value the parking pass wrote
+ * — which is why the production evidence looked like a correct deadline
+ * being ignored rather than a wrong one being computed.
+ *
+ * Usage:
+ *   docker exec formr_app php /formr/bin/test_wait_tail_anchor_probe.php
+ */
+require_once dirname(__FILE__) . '/../setup.php';
+
+$run_id  = (int) ($argv[1] ?? 43);
+$unit_id = (int) ($argv[2] ?? 707);   // Wait at position 50, wait_minutes = 10
+$tail_unit = (int) ($argv[3] ?? 713); // SkipBackward at position 110
+
+$db  = DB::getInstance();
+$run = new Run(null, $run_id);
+if (!$run->valid) { fwrite(STDERR, "run {$run_id} not valid\n"); exit(1); }
+
+$wm   = (float) $db->findValue('survey_pauses', ['id' => $unit_id], 'wait_minutes');
+$secs = (int) ($wm * 60);
+
+$cleanup = [];
+
+/**
+ * @param int $tail_age how many seconds ago the highest-unit_id session was created
+ */
+$failures = 0;
+
+/**
+ * @param string $expect 'run_to' (participant returned early) or 'move_on'
+ */
+function scenario(string $label, int $run_id, int $unit_id, int $tail_unit, int $tail_age, int $secs, bool $hydrate = false, string $expect = 'run_to', int $wait_age = 1) {
+    global $db, $run, $cleanup, $failures;
+
+    $key = 'TAIL' . bin2hex(random_bytes(26));
+    $db->insert('survey_users', ['user_code' => $key, 'created' => mysql_datetime(time())]);
+    $user_id = $db->lastInsertId();
+    $db->insert('survey_run_sessions', [
+        'run_id' => $run_id, 'session' => $key, 'user_id' => $user_id,
+        'position' => 50, 'created' => mysql_datetime(time() - 1800),
+    ]);
+    $rs_id = $db->lastInsertId();
+    $cleanup[] = [$rs_id, $user_id];
+
+    // A realistic multi-cycle history, shaped like a real ESM session so the
+    // optimizer picks the same plan (drive survey_run_units -> per-unit ref
+    // lookup into survey_unit_sessions, i.e. output grouped by unit).
+    // Units 703/704/705 are hit every cycle; 712/713 only on the
+    // self-init branch, so they lag behind.
+    $insert = function (int $uid, int $age) use ($db, $rs_id) {
+        $db->insert('survey_unit_sessions', [
+            'run_session_id' => $rs_id, 'unit_id' => $uid,
+            'created' => mysql_datetime(time() - $age), 'ended' => mysql_datetime(time() - $age + 1),
+        ]);
+    };
+    foreach ([1500, 1200, 900, 600, 300, 120, 60, 20] as $age) {
+        $insert(703, $age); $insert(704, $age - 1); $insert(705, $age - 2);
+    }
+    foreach ([1450, 1150, 550, 250, 90] as $age) { $insert(706, $age); $insert(710, $age - 1); $insert(711, $age - 2); }
+    // The lagging branch: last visited $tail_age seconds ago.
+    $insert(712, $tail_age + 1);
+    $insert($tail_unit, $tail_age);
+
+    // The Wait the participant is parked at, parked by the cascade with the
+    // CORRECT expires (created + wait_minutes).
+    $created = time() - $wait_age;
+    $db->insert('survey_unit_sessions', [
+        'run_session_id' => $rs_id, 'unit_id' => $unit_id,
+        'created' => mysql_datetime($created),
+        'expires' => mysql_datetime($created + $secs), 'queued' => 2,
+    ]);
+    $us_id = $db->lastInsertId();
+
+    $runSession = new RunSession($key, $run);
+    // The participant returning is a web request, not the daemon. In console
+    // User::isCron() defaults true, which would mask the run_to branch.
+    $runSession->user->cron = false;
+    $runUnit = RunUnitFactory::make($run, ['id' => $unit_id]);
+
+    if ($hydrate) {
+        // The proposed fix: make getCurrentUnitSession() actually load().
+        $unitSession = new UnitSession($runSession, $runUnit, ['id' => $us_id, 'load' => true]);
+    } else {
+        // Hydrate exactly as RunSession::getCurrentUnitSession():534 does.
+        $row = $db->findRow('survey_unit_sessions', ['id' => $us_id],
+            'id, unit_id, run_session_id, created, expires, ended, expired');
+        $unitSession = new UnitSession($runSession, $runUnit, $row);
+    }
+
+    $res = $unitSession->execute();
+    $verdict = 'other';
+    if (!empty($res['expired']))         { $unitSession->expire(); $verdict = 'expire()'; }
+    elseif (!empty($res['end_session'])) { $unitSession->end();    $verdict = 'end()'; }
+
+    $r = new ReflectionObject($runUnit);
+    while ($r && !$r->hasProperty('relative_to_result')) { $r = $r->getParentClass(); }
+    $p = $r->getProperty('relative_to_result'); $p->setAccessible(true);
+    $anchor = $p->getValue($runUnit);
+
+    $after = $db->findRow('survey_unit_sessions', ['id' => $us_id], 'result, expires');
+    $branch = isset($res['run_to']) ? 'run_to = ' . var_export($res['run_to'], true)
+            : (!empty($res['move_on']) ? 'move_on -> next position (Email at 60)' : 'none');
+
+    $got = isset($res['run_to']) ? 'run_to' : (!empty($res['move_on']) ? 'move_on' : 'none');
+    $ok  = ($got === $expect);
+    if (!$ok) { $failures++; }
+
+    printf("%s %s\n", $ok ? "\e[32mPASS\e[0m" : "\e[31mFAIL\e[0m", $label);
+    printf("    lagging unit last seen %ds ago | Wait entered %ds ago, deadline %ds\n", $tail_age, $wait_age, $secs);
+    printf("    tail() anchor resolved to: %s\n", var_export($anchor, true));
+    printf("    expected %s, got %s (%s) via %s | DB result=%s expires=%s\n\n",
+        $expect, $got, $branch, $verdict, var_export($after['result'], true), var_export($after['expires'], true));
+}
+
+echo "== Wait unit {$unit_id}, wait_minutes = {$wm} ({$secs}s); tail unit = {$tail_unit} ==\n\n";
+
+// A participant returning 1 second into a 10-minute Wait must always take
+// run_to = body, whatever the rest of their history looks like.
+scenario("A lagging unit last seen 29s ago",        $run_id, $unit_id, $tail_unit, 29, $secs);
+// B is the regression case: pre-fix this returned move_on -> Email at 60.
+// It hydrates the way getCurrentUnitSession() used to, so it stays honest
+// about the ORDER BY fix even once the load() fix is in place.
+scenario("B lagging unit stale (20 min ago)",       $run_id, $unit_id, $tail_unit, 1200, $secs);
+scenario("C stale history, load()ed unit session", $run_id, $unit_id, $tail_unit, 1200, $secs, true);
+// D a genuinely elapsed Wait must still move on.
+scenario("D genuine elapse still moves on",         $run_id, $unit_id, $tail_unit, 29, $secs, true, 'move_on', $secs + 60);
+
+foreach ($cleanup as [$rs_id, $user_id]) {
+    $db->exec('DELETE FROM survey_unit_sessions WHERE run_session_id = :id', ['id' => $rs_id]);
+    $db->exec('DELETE FROM survey_run_sessions WHERE id = :id', ['id' => $rs_id]);
+    $db->exec('DELETE FROM survey_users WHERE id = :id', ['id' => $user_id]);
+}
+echo "(cleaned up " . count($cleanup) . " probe run sessions)\n";
+echo $failures === 0 ? "\e[32mALL SCENARIOS PASS\e[0m\n" : "\e[31m{$failures} SCENARIO(S) FAILED\e[0m\n";
+exit($failures === 0 ? 0 : 1);

--- a/documentation/agent_doc/wait_premature_expiry_bug.md
+++ b/documentation/agent_doc/wait_premature_expiry_bug.md
@@ -1,10 +1,69 @@
 # BUG: Wait unit records a participant's early return as `expired`
 
-**Status:** open, not reproduced locally. Investigation handoff.
+**Status: RESOLVED** — reproduced locally on v1.1.1 and fixed on
+`fix/wait-premature-expiry`. **Sections 1–10 below are the original
+handoff and are preserved for provenance, but several of their
+conclusions are wrong.** Read this header first.
 **First observed:** 2026-08-09, production run `esm` on
 `formr-admin.uni-muenster.de`.
-**Filed by:** prior investigation session (see "What is already ruled
-out" before repeating work).
+**Filed by:** prior investigation session.
+
+## Root cause (2026-08-09)
+
+Two defects compound; neither is sufficient alone.
+
+1. **Hydration regression.** `RunSession::getCurrentUnitSession()`
+   passed a full DB row to `new UnitSession()`, but the constructor's
+   `$options` allowlist (`ed56a95f`, 2026-05-04, shipped in v1.0.0 —
+   so present in v1.1.1 *and* v1.4.0) keeps only `id`/`load`, and the
+   row carries no `load` key, so `load()` never ran. Every participant
+   web request at a parked Wait therefore ran with `created = NULL`
+   and `expires = NULL`, defeating both fast paths in
+   `Pause::getUnitSessionExpirationData()` (`:120`, `:128`) and forcing
+   the wait anchor through OpenCPU's
+   `tail(survey_unit_sessions$created, 1)`.
+2. **Unordered run-data frame.** The query behind that data frame
+   (`UnitSession::getRunData()`) had **no `ORDER BY`**. The optimizer
+   drives from `survey_run_units` and does a per-unit ref lookup, so
+   rows come back grouped by unit: `tail(...,1)` returns the newest
+   session of *whichever unit sorts last*, not the most recent session.
+   Measured staleness: 72 s on a real local ESM session, two days at
+   2.4k rows, two weeks at 20k rows.
+
+When that stale anchor is older than `wait_minutes`, the Wait reports
+`expired` the instant the participant returns. `UnitSession::execute()`
+then short-circuits (`:176`) without ever calling
+`Wait::getUnitSessionOutput()`, and `RunSession::executeUnitSession()`
+tests `expired` first (`:370`) → `expire()` → `move_on`. Because
+`expire()` never writes `expires`, the column keeps the correct value
+the parking pass wrote — which is why the deadline *looked* correct.
+
+**Fixes:** pass `['id', 'load' => true]` in `getCurrentUnitSession()`;
+add `ORDER BY survey_unit_sessions.created, survey_unit_sessions.id`
+to the run-data query. Regression harness:
+`bin/test_wait_tail_anchor_probe.php` (exit code 0/1).
+
+## Corrections to the sections below
+
+- **§1 / §4 "the computed deadline is correct in every observed case"
+  is unsound.** `expire()` never writes `expires`, so that column
+  records the earlier *parking* pass, not the exit that classified the
+  row. The exit-time deadline is not persisted anywhere.
+- **§6 #4 ("`relative_to` resolving to a stale anchor — disproved") was
+  the actual cause.** The old probe saw the `Pause.php:128` fast path
+  taken only because it hydrates with `load => true`, which the real
+  web path did not.
+- **§6 #2 is void** for the same reason as §1.
+- **§7's "sharpest structural lead" (the Wait three-way branch) is a
+  dead end** — that branch is never reached on the failing path.
+- **§8 H1, H2, H5 are not needed.** H3 stays excluded for row 1763062
+  by the §7 numerical-trap argument, which survives. H4 is a real
+  latent fail-open, still unfixed, tracked separately.
+- **§2's version caveat resolves:** v1.1.1 contains the bug; the
+  v1.4.0 source was never needed.
+- **§5's non-reproduction is explained:** the local control session ran
+  only 7 minutes, so a 10-minute Wait's anchor could not yet be stale
+  enough to misfire.
 
 ---
 

--- a/documentation/agent_doc/wait_premature_expiry_bug.md
+++ b/documentation/agent_doc/wait_premature_expiry_bug.md
@@ -1,0 +1,449 @@
+# BUG: Wait unit records a participant's early return as `expired`
+
+**Status:** open, not reproduced locally. Investigation handoff.
+**First observed:** 2026-08-09, production run `esm` on
+`formr-admin.uni-muenster.de`.
+**Filed by:** prior investigation session (see "What is already ruled
+out" before repeating work).
+
+---
+
+## 1. Symptom in one sentence
+
+A `Wait` unit whose participant returns **before** the wait elapses is
+sometimes recorded with `result = 'expired'` and takes the `move_on`
+branch (advance to the next position) instead of the `run_to = body`
+branch (jump to the unit the Wait points at) — which on the `esm` run
+sends a reminder Email that should have been skipped.
+
+**This is not a broken timer.** The computed deadline is correct in
+every observed case. What goes wrong is the *classification of the
+exit*, not the arithmetic.
+
+---
+
+## 2. Version caveat — read this first
+
+The production instance that produced the evidence reports
+**`v1.4.0`** in its admin footer (`FORMR_VERSION` is
+`file_get_contents(VERSION)`, see `setup.php:3`). **This repo is
+`v1.1.1`**, and no `v1.4.0` tag exists on `origin`
+(github.com/timseidel/formr.org) or `upstream`
+(github.com/rubenarslan/formr.org); `CHANGELOG-v1.md` archives the
+0.19.x lineage, so it is not an older numbering scheme either.
+
+So the production code is **not in this repo**. Every line reference
+below is to **v1.1.1** and may not describe what actually ran.
+
+The current working assumption for this investigation — set by the
+repo owner — is: **assume v1.1.1 also contains the bug and hunt for it
+here.** If a systematic pass through §8 exhausts the hypotheses without
+finding it, that assumption is what to revisit; obtaining the v1.4.0
+source becomes the next step.
+
+---
+
+## 3. The run under test
+
+Run `esm` (local run_id **43**). Relevant units:
+
+| position | type | key config |
+|---|---|---|
+| 10 | Survey | `state_master` — calculate + submit, auto-advances |
+| 20 | SkipForward | `condition = FALSE`, `if_true = 120` |
+| **30** | **Wait** | `wait_minutes = 1`, **`body = 100`** |
+| 40 | PushMessage | — |
+| **50** | **Wait** | `wait_minutes = 10`, **`body = 80`** |
+| **60** | **Email** | the reminder that must not fire |
+| 70 | Wait | `wait_minutes = 1`, `body` empty |
+| 80 | Survey | `time_init_ping` |
+| 90 | SkipBackward | `condition = TRUE`, `if_true = 10` |
+| 100 | Survey | `self_init_ping` (1-minute inactivity expiry) |
+| 110 | SkipBackward | `condition = TRUE`, `if_true = 10` |
+| 120 | Page | endpage |
+
+`body` on a Wait is a **jump target**, not display text. The design is:
+
+- Wait(30) — 1 minute for the participant to self-initiate. If they
+  show up → jump to **100** (`self_init_ping`). If not → fall through
+  to **40** (push notification).
+- Wait(50) — 10-minute response window after the push. If they show up
+  → jump to **80** (`time_init_ping`). If not → fall through to **60**
+  (Email reminder).
+
+So **reaching position 60 is only correct after a full 10 minutes of
+silence.** Every observed bad case reached it within 1 second.
+
+---
+
+## 4. Evidence — production (v1.4.0)
+
+Run `esm`, session `FoYPw0roKpmK-nY_…`, 2026-08-09 13:34–13:56.
+Source: admin user-detail view (the CSV export at the time lacked
+`expires`; that gap is now fixed, see §11).
+
+### Wait at position 50 (`wait_minutes = 10`, `body = 80`)
+
+| unit_session | entered | `expires` | exited after | `result` | went to |
+|---|---|---|---|---|---|
+| 1762987 | 13:37:13 | 13:47:13 | 98 s | `wait_ended` | 80 ✅ |
+| 1763013 | 13:41:38 | 13:51:38 | 0 s | `wait_ended` | 80 ✅ |
+| **1763043** | 13:49:51 | **13:59:51** | **1 s** | **`expired`** | **60 → Email sent** ❌ |
+| 1763064 | 13:51:40 | *(blank)* | 0 s | `wait_ended` | 80 ✅ |
+| **1763079** | 13:54:21 | **14:04:21** | **0 s** | **`expired`** | **60 → Email sent** ❌ |
+
+### Wait at position 30 (`wait_minutes = 1`, `body = 100`)
+
+| unit_session | entered | `expires` | exited after | `result` | went to |
+|---|---|---|---|---|---|
+| 1763040 | 13:48:50 | 13:49:50 | 60 s | `wait_ended` | 40 ✅ (genuine elapse) |
+| **1763062** | 13:51:26 | **13:52:26** | **13 s** | **`expired`** | **40** ❌ (47 s early) |
+| 1763076 | 13:53:16 | 13:54:16 | 64 s | `wait_ended` | 40 ✅ |
+
+**`expires` is correct on every row, including the bad ones.** The bug
+is intermittent — the same unit takes the right branch most of the
+time.
+
+### Note on `1763064`
+
+Blank `expires` means `queue()` never ran, i.e. the very first
+execution of that unit session was a web request that took `run_to`
+immediately. The bad rows *do* have `expires`, so they parked as cron
+first and were exited by a **second** event.
+
+---
+
+## 5. Evidence — local control (v1.1.1), NOT reproduced
+
+Local Docker, run 43, session `wonderfulMillipede…`, 2026-08-09
+14:42–14:49. Same run structure, push notifications working
+(`result = 'sent'`).
+
+| unit_session | pos | entered | `expires` | exited after | `result` | went to |
+|---|---|---|---|---|---|---|
+| 8193 | 30 | 14:46:30 | 14:47:30 | **13 s** | `wait_ended` | **100** ✅ |
+| 8183 | 50 | 14:44:54 | 14:54:54 | **1 s** | `wait_ended` | **80** ✅ |
+| 8205 | 50 | 14:48:54 | 14:58:54 | 7 s | `wait_ended` | 80 ✅ |
+| 8181 | 30 | 14:43:50 | 14:44:50 | 63 s | `wait_ended` | 40 ✅ |
+| 8203 | 30 | 14:47:50 | 14:48:50 | 64 s | `wait_ended` | 40 ✅ |
+
+**The matched pairs are the sharpest evidence available:**
+
+| | entered | `expires` | exited after | `result` | went to |
+|---|---|---|---|---|---|
+| local 8193 Wait(30) | 14:46:30 | 14:47:30 | 13 s | `wait_ended` | 100 ✅ |
+| prod 1763062 Wait(30) | 13:51:26 | 13:52:26 | 13 s | **`expired`** | 40 ❌ |
+| local 8183 Wait(50) | 14:44:54 | 14:54:54 | 1 s | `wait_ended` | 80 ✅ |
+| prod 1763043 Wait(50) | 13:49:51 | 13:59:51 | 1 s | **`expired`** | 60 ❌ |
+
+Identical timing, identical early exit, opposite classification.
+
+The local session never left a Wait(50) idle for a full 10 minutes, so
+the **genuine**-elapse path into the Email is untested locally. Worth
+running once as a control (it should reach the Email legitimately).
+
+---
+
+## 6. What is already ruled out — do not redo
+
+| # | Ruled out | How |
+|---|---|---|
+| 1 | `wait_minutes` not loading | `survey_pauses.wait_minutes = 10.00` on unit 707; probe confirms it reaches `parseRelativeTo()` intact |
+| 2 | Deadline miscomputed | `expires` correct on all bad rows (§4) |
+| 3 | Missing `survey_pauses` row → empty `$conditions` → fail-open | row exists and loads |
+| 4 | `relative_to` resolving through OpenCPU to a stale anchor | disproved by 2; probe shows the fast path at `Pause.php:128` is taken, `relative_to_result` = the unit session's own `created` |
+| 5 | `Wait::setDefaultRelativeTo()` corrupting the anchor | it is **dead code** in the normal path (see §8 H2) — probe shows `default_relative_to` unchanged after evaluation |
+| 6 | Isolated Wait evaluation | 6 scenarios (fresh / stored-expires-future / stored-expires-past × web / cron) all correct — `bin/test_wait_expiry_probe.php` |
+| 7 | Daemon cascade Wait(30)→Push(40)→Wait(50) | Wait(50) parked correctly with `expires = created + 600`, `queued = 2`, no Email — `bin/test_wait_cascade_probe.php 43 30` |
+| 8 | Genuine elapse → Email | confirmed correct — `bin/test_wait_cascade_probe.php 43 50` |
+| 9 | Multiple queue workers racing (locally) | one container, `php bin/queue.php -t UnitSession`, single process. **Still unverified on production** |
+
+---
+
+## 7. Code map and the sharpest structural lead (v1.1.1)
+
+### The three-way branch — `application/Model/RunUnit/Wait.php:50-69`
+
+```php
+if (empty($expiration['expired']) && !$unitSession->isExecutedByCron()
+        && empty($expiration['check_failed'])) {
+    $output['end_session'] = true;
+    $output['run_to']      = $this->body;      // ← participant returned
+} elseif ($expiration['expired'] === true) {
+    $output['end_session'] = true;
+    $output['move_on']     = true;             // ← elapsed
+} else {
+    $output['wait_user'] = true;               // ← still waiting
+}
+```
+
+### Other relevant sites
+
+- `application/Model/RunUnit/Pause.php:111-253` — `getUnitSessionExpirationData()`
+  - `:120-124` early return when a stored `expires` is still in the future
+  - `:176-187` the `has_wait_minutes` branch that builds `$conditions['minute']`
+  - `:226-248` SQL evaluation of `$conditions`, **including the fail-open
+    `else { $result = true; }` at `:246`**
+  - `:250` `$data['end_session'] = $data['expired'] = $result;`
+- `application/Model/UnitSession.php`
+  - `:167-191` `execute()`
+  - `:193-222` `isExpired()` — merges the whole `$expirationData` into
+    `execResults` at `:198` **before** deciding, and checks
+    `end_session` **before** `expires < time()`
+  - `:241-277` `expire()` — the **only** writer of `survey_unit_sessions.expired`
+- `application/Model/RunSession.php`
+  - `:211-329` `execute()` — named lock, `reloadFromDb()`, and the
+    **END-q** branch at `:289`
+  - `:363-417` `executeUnitSession()` — tests `!empty($result['expired'])`
+    **first**, before `end_session`, and calls `expire()` at `:370-372`
+- `application/Queue/UnitSessionQueue.php`
+  - `:107-134` `getSessionsStatement()` — `ORDER BY RAND()`, **no LIMIT,
+    no atomic claim / `FOR UPDATE`**
+  - `:172` sets `$runSession->user->cron = true`
+  - `:178` `execute($unitSession, $queued == QUEUED_TO_EXECUTE)`
+  - `:232-250` `addItem()` writes `expires` + `queued`
+
+### ★ The sharpest lead: `expired` rules out the END-q path
+
+`expire()` (`UnitSession.php:241`) is the only code that writes
+`survey_unit_sessions.expired`. The daemon's normal path for a
+`QUEUED_TO_END` row is the **END-q** branch at `RunSession.php:289`,
+which calls `endCurrentUnitSession()` → `end()` and produces
+`ended` + `result = 'wait_ended'` — **never `expired`**.
+
+The bad production rows have `expired` set and `result = 'expired'`.
+Therefore they did **not** come through END-q. They reached
+`executeUnitSession()`, which happens only when:
+
+- **(a)** a **web request** drove `RunSession::execute()`, or
+- **(b)** the daemon drove it with `$executeReferenceUnit = true`,
+  i.e. the row was `QUEUED_TO_EXECUTE` (1), not `QUEUED_TO_END` (2).
+
+Path (b) is reachable only via `UnitSession::isExpired():200-207`,
+which rewrites `expires` to `now + queue_expiration_extension`
+(default `'+10 minutes'`) and `queued` to `QUEUED_TO_EXECUTE` when
+`check_failed === true || expire_relatively === false`.
+
+**Numerical trap when checking (b):** for the Wait at position 50,
+`wait_minutes = 10`, so the correct deadline (`created + 600 s`) and
+the failure deadline (`now + 10 minutes`) are **numerically
+identical**. `expires = 13:59:51` on row 1763043 cannot distinguish
+them. Use the Wait at position **30** to disambiguate:
+`wait_minutes = 1`, so correct = `created + 60 s` = 13:52:26 while the
+failure path would give 14:01:26. Row 1763062 shows **13:52:26**, i.e.
+the normal path — which argues against (b) for that row, but the two
+Wait(50) rows remain ambiguous.
+
+---
+
+## 8. Ranked hypotheses, each with a falsifiable check
+
+### H1 — Web request racing the daemon cascade ★ most likely
+
+**Mechanism.** The participant taps the push at position 40 while the
+daemon is still cascading. `RunSession::execute()` takes a named lock
+with a **10 s** timeout for web but only **0.1 s** for console
+(`:222-225`), then `reloadFromDb()` (`:246`). Two actors interleaving
+around the same run session can leave `execResults` describing one
+unit while `$this->currentUnitSession` is another. `executeUnitSession()`
+tests `!empty($result['expired'])` **first** (`:370`), so any leakage of
+a truthy `expired` into `$result` expires the row regardless of what
+the Wait's own branch intended.
+
+**Fits:** intermittency; only production has a live participant; the
+push at position 40 is exactly the event that makes both actors move
+at once; the codebase already documents this failure class at
+`RunSession.php:236-245` (the AMOR 2026-05-09 incident, duplicate
+downstream unit sessions from two near-simultaneous requests).
+
+**Check.** Set `$settings['unit_session']['debug'] = true` in
+`config/settings.php` (default `false`,
+`config-dist/settings.php:244`), then drive the run while hammering the
+participant URL from a second shell so requests overlap the cascade.
+Watch `docker logs -f formrsessionqueue`. Look for two executions of
+the same `run_session_id` within the same second.
+
+### H2 — Double evaluation with mutated RunUnit instance state
+
+**Mechanism.** `getUnitSessionExpirationData()` is called **twice** per
+`execute()` on the *same* `Wait` object — once from
+`UnitSession::isExpired()` (`UnitSession.php:194`) and again from
+`Wait::getUnitSessionOutput()` (`Wait.php:52`). `parseRelativeTo()`
+mutates instance state on every call: it reassigns `$this->relative_to`,
+casts/trims `$this->wait_minutes` to a string, and sets the
+`has_relative_to` / `has_wait_minutes` flags.
+
+Related, and confirmed: **`Wait::setDefaultRelativeTo()` is dead code.**
+`Wait.php:46` calls it *before* `parseRelativeTo()` sets
+`has_wait_minutes`, so its own guard
+(`$this->has_wait_minutes && !$this->has_relative_to`, `:33`) is false
+on the first call; on later calls `has_relative_to` is already true, so
+it is false again. It never fires. When it *would* fire it writes
+`json_encode($created)` — a quoted string that no longer matches the
+`tail(...)` literal at `Pause.php:128`, diverting the anchor through
+OpenCPU. Harmless today, but a trap if the ordering is ever "fixed"
+without care.
+
+**Check.** Log both calls' full return arrays plus the instance state
+between them. Extend `bin/test_wait_expiry_probe.php` (it already has a
+reflection helper `peek()`).
+
+### H3 — `QUEUED_TO_EXECUTE` re-entry via `check_failed`
+
+**Mechanism.** `UnitSession::isExpired():200-207` rewrites `expires` to
+`now + '+10 minutes'` and `queued` to `QUEUED_TO_EXECUTE` when
+`check_failed === true` (OpenCPU failure) or
+`expire_relatively === false`. A `QUEUED_TO_EXECUTE` row makes the
+daemon pass `$executeReferenceUnit = true` (`UnitSessionQueue.php:178`),
+which **skips END-q** and goes to `executeUnitSession()` — the only
+daemon path that can call `expire()`.
+
+**Note:** `expire_relatively` is `null` for a `wait_minutes` Wait, and
+`null === false` is false, so only `check_failed` can trigger this.
+
+**Fits partially.** Explains `expired` rather than `ended`. But see the
+numerical trap in §7: row 1763062 (Wait 30, `wait_minutes = 1`) has
+`expires = created + 60 s`, not `+10 minutes`, so this path did **not**
+produce that row. It remains possible for the two Wait(50) rows.
+
+**Check.** Grep the production/OpenCPU logs for errors at 13:49:5x and
+13:54:2x. Locally, force it: point `relative_to` at deliberately broken
+R, or stop the `opencpu` container mid-cascade.
+
+### H4 — `$conditions` fail-open at `Pause.php:246`
+
+**Mechanism.** If `$conditions` ends up empty, the `else` branch sets
+`$result = true` unconditionally → `expired = true`. This is a
+**fail-open** guard: a Wait with no usable condition is declared
+elapsed rather than raising.
+
+**Fits poorly** — reaching an empty `$conditions` requires
+`has_wait_minutes` false, which contradicts the correct `expires`
+values. Listed because it is a genuine latent defect worth fixing
+regardless, and because instance-state mutation (H2) could in principle
+produce it on the *second* call.
+
+**Check.** Assert `$conditions` non-empty for any unit with
+`wait_minutes > 0`; log and raise instead of defaulting to `true`.
+
+### H5 — Multiple queue workers on production
+
+**Mechanism.** `getSessionsStatement()` (`UnitSessionQueue.php:119-126`)
+does `ORDER BY RAND()` with **no LIMIT, no `FOR UPDATE`, no atomic
+claim**. Two workers select overlapping row sets and both process them.
+The per-run-session named lock is the only guard, and console callers
+give up after 0.1 s.
+
+**Check (production only, cannot be checked locally).** Ask the
+Münster admin for the supervisord/compose config: does
+`bin/queue.php -t UnitSession` run with `-n`/`-p` sharding or
+`numprocs > 1`? Locally it is a single process, which is consistent
+with the local non-reproduction.
+
+---
+
+## 9. Tools already built
+
+Both live in `bin/` alongside this report:
+
+- **`bin/test_wait_expiry_probe.php <run_id> <unit_id>`** — drives
+  `UnitSession::execute()` through six scenarios (fresh /
+  stored-expires-future / stored-expires-past × web / cron) and dumps
+  the branch taken plus protected internals via reflection.
+  `docker exec formr_app php /formr/bin/test_wait_expiry_probe.php 43 707`
+- **`bin/test_wait_cascade_probe.php <run_id> <start_position>`** —
+  parks a throwaway participant with an already-past `expires`, runs
+  one real `UnitSessionQueue` pass, and prints every unit session the
+  cascade produced plus whether the Email was reached.
+  `docker exec formr_app php /formr/bin/test_wait_cascade_probe.php 43 30`
+
+**Environment gotchas** (these cost the last session time):
+
+- The repo bind-mounts at **`/formr`**, not `/var/www/formr`.
+- Daemon containers are **`formrsessionqueue`** / **`formrmailqueue`**,
+  not the `formr_run_daemon` / `formr_mail_daemon` names in CLAUDE.md.
+  **Stop `formrsessionqueue` before driving `runOnce()` by hand**, or
+  the live daemon races the deterministic pass.
+- `survey_run_sessions` has `UNIQUE KEY run_user (user_id, run_id)` —
+  a harness making several participants on one run must insert a
+  distinct `survey_users` row per session, else the second insert dies
+  with a bare `Error [1] in application/DB.php` (the 500 handler hides
+  the PDO message).
+- DB client is `mariadb`, not `mysql`; credentials are env vars inside
+  `formr_db`.
+
+---
+
+## 10. Suggested order of work
+
+1. **Control run first.** Leave a Wait(50) untouched for a full 10
+   minutes locally and confirm the Email fires legitimately. Establishes
+   the baseline the bug deviates from.
+2. **H1.** Enable queue debug, drive the run with overlapping web
+   requests. Highest prior, and the only hypothesis that explains the
+   intermittency without extra machinery.
+3. **H2.** Instrument the two `getUnitSessionExpirationData()` calls.
+   Cheap, and rules in/out a whole class of state-mutation bugs.
+4. **H3.** Force an OpenCPU failure mid-cascade.
+5. **H4/H5.** Fix H4 regardless (fail-open → fail-closed). H5 needs
+   production access.
+
+**The signature to watch for**, now visible in the CSV export: a Wait
+with `result = 'expired'` whose *next* unit session is the position
+after it rather than its `body` target. `expires` alone will not reveal
+it — it is correct on the bad rows.
+
+---
+
+## 11. Related export fixes — check whether your tree has them
+
+Two fixes to `RunHelper::getUserDetailExportPdoStatement()`
+(`application/Helper/RunHelper.php`) came out of this investigation.
+They ship on their own branch, so **the tree you are reading this in
+may or may not contain them.** Check before trusting any CSV export.
+
+**(a) `seconds_stayed` was wrong for every expired unit session.** The
+column was computed as:
+
+```sql
+IF (ended > 0, UNIX_TIMESTAMP(ended)   - UNIX_TIMESTAMP(created),
+               UNIX_TIMESTAMP(NOW())   - UNIX_TIMESTAMP(created))
+```
+
+An expired session has `ended` NULL, so it fell into the `NOW()` branch
+and reported *time since the participant entered the unit, as of the
+moment of export* — not a duration. The number grew on every
+re-export and contradicted the timestamps in the web view. Fixed by
+falling back to `expired` before `NOW()`, so `NOW()` applies only to
+sessions still genuinely open.
+
+*Symptom if your tree lacks it:* in the production evidence a Wait that
+actually lasted 1 s exported as `424`, and all nine expired rows
+resolved to the same wall-clock instant (`entered + seconds_stayed` ==
+export time).
+
+**(b) The export was missing `expires`, `queued`, `result` and
+`result_log`.** It carried only `created` / `ended` / `expired`, while
+the admin web view (`templates/admin/run/user_detail.php`) also renders
+`expires` — bolded while `queued > 0` — and `result` with `result_log`
+as its tooltip. Fixed by appending the four columns (appended, not
+inserted, so positional parsers of the old 9-column format keep
+working).
+
+*Why this matters here:* **without `expires` the bug documented above is
+invisible in an export.** The deadline a Pause/Wait actually computed
+lives only in that column, so an export showing a 10-minute Wait ending
+after 1 second gives no way to tell whether the deadline was
+miscomputed or a correct deadline was ignored. Establishing that it was
+the latter — the finding §1 rests on — originally required a PDF print
+of the admin web view.
+
+**Verify quickly.** A fixed export has 13 columns:
+
+```
+session_id, position, unit_type, description, session, entered,
+seconds_stayed, left, expired, expires, queued, result, result_log
+```
+
+If yours has 9 and stops at `expired`, neither fix is present; export
+parity is a prerequisite for the diagnostic in §10.


### PR DESCRIPTION
Encountered on the Münster formr server with attached ESM run, reproduced locally.
Uncertain, if the newer than repo v1.4.0 on the server has any effect - dont think so.
Thanks and LG!
Tim

[esm_user_detail.csv](https://github.com/user-attachments/files/30874519/esm_user_detail.csv)
[esm.json](https://github.com/user-attachments/files/30874520/esm.json)
[formr admin user details.pdf](https://github.com/user-attachments/files/30874521/formr.admin.pdf)
-> The formr admin user details dont match the esm_user_detail.csv, web is right. Its another bug, will create another PR :)

This is a fix for a bug introduced by a security commit on May 4th:
[`ed56a95f`](https://github.com/rubenarslan/formr.org/commit/ed56a95f1f22ed62c01703a9c5218e21dbe09543).

Specifically the defense-in-depth allowlist on the `UnitSession`
constructor (`{id, load}`). It's a good thing, but it necessitates
loading the other values from the DB — which wasn't done in
`getCurrentUnitSession()`, as it passes a full row and never sets
`load`. The commit message even spells out the assumption it made
("set by Run.php / Queue"); `getCurrentUnitSession()` is a third caller
nobody counted.

So every participant web request at a parked Wait arrived with
`created` and `expires` silently dropped. That skips both fast paths in
`Pause::getUnitSessionExpirationData()` and pushes the wait anchor onto
the slow path — OpenCPU evaluating `tail(survey_unit_sessions$created, 1)`
against `getRunData()`, which wasn't ordered. So yes, with the DB
optimizer doing its thing it worked sometimes and sometimes not.

I.e. the error that led me here — run `esm`, Wait at position 50,
`wait_minutes = 10`, `body = 80`:

| unit_session | entered | `expires` | exited after | `result` | went to |
|---|---|---|---|---|---|
| 1762987 | 13:37:13 | 13:47:13 | 98 s | `wait_ended` | 80 ✅ |
| **1763043** | 13:49:51 | **13:59:51** | **1 s** | **`expired`** | **60 → reminder Email sent** ❌ |
| **1763079** | 13:54:21 | **14:04:21** | **0 s** | **`expired`** | **60 → reminder Email sent** ❌ |

Participants got a reminder mail seconds after responding.

Two details that cost me time, in case they save yours:

- **`expires` is correct on the bad rows, and that's a red herring.**
  `expire()` never writes `expires`, so that column records the earlier
  *parking* pass — not the exit that misclassified the row. The deadline
  actually computed at exit time isn't persisted anywhere. It looks like
  a correct deadline being ignored; it was a wrong one being computed.
- **The row order isn't random, which is why it's intermittent rather
  than just broken.** The optimizer drives from `survey_run_units` and
  does a per-unit lookup, so rows come back grouped by unit — `tail(…,1)`
  reliably returns the newest session of *whichever unit sorts last*.
  On `esm` that's the SkipBackward at position 110, only reached via the
  position-100 branch. A participant looping through 80/90 leaves it to
  go stale, and it bites once it's staler than `wait_minutes`. Measured:
  72 s on a local session, ~42 h at 2.4k rows/participant, ~14 days at
  20k. On a long diary study it stops being intermittent.

## Fixes

1. **`getCurrentUnitSession()` passes `['id', 'load' => true]`** instead
   of the raw row, so `load()` runs. Keeps the allowlist's protection
   fully intact rather than widening it; costs one extra `findRow`.
2. **`getRunData()` gets `ORDER BY survey_unit_sessions.created,
   survey_unit_sessions.id`.** `created` is what `tail()` is actually
   asking for; `id` breaks ties, which are real — a cascade creates
   several unit sessions inside the same second. This also fixes
   `tail()`/`head()` idioms in study-authored R, which read the same
   frame. ~0.2 ms at 2.4k rows: the sort set is one participant's
   history, not the table.
3. **Cleaner logging for the user-returns state.** A Wait that genuinely
   elapsed was recorded as `result='expired'` whenever a web request
   drove it, while the daemon's END-q path recorded the same event as
   `'wait_ended'`. `isExpired()` was leaking a merged `expired` key past
   the branch whose own comment reads `// ended NOT expired`, and
   `executeUnitSession()` tests `expired` first. Same branch taken either
   way, but now the audit trail says what happened — which matters,
   because `result` alone previously couldn't distinguish a normal elapse
   from this bug.

   Worth being explicit that (3) is **not** the fix: with (2) reverted and
   (3) alone in place, the probe still routes the participant to the Email
   — it just records the row as a healthy `wait_ended` while doing it. The
   `expired` label was the only visible tell, so shipping (3) without
   (1)+(2) would have hidden the bug rather than fixed it.

Not touched: the fail-open at `Pause.php:247` (a Wait with no usable
condition is declared elapsed). Reachable and it produces the same
signature, but that behaviour is intended, and its path returns before
the branch changed in (3).

## Testing

`bin/test_wait_tail_anchor_probe.php` is the regression harness (exits
0/1). Scenario B is the production case above — participant returns 1 s
into a 10-minute Wait with a 20-minute-stale lagging unit: `move_on` →
Email before, `run_to = 80` now. It deliberately still hydrates the old
way so it keeps testing fix (2) independently of fix (1). Scenario D
checks a genuine elapse still moves on.

Also: `composer test` 162/162, `ConstructorSmugglingTest` 4/4, Survey and
External expiry verified unchanged by hand (no PHPUnit coverage exists
for those — the leak fix in (3) is scoped to Pause/Wait by construction,
since Survey/External never set `end_session` and Branch never sets
`expired`).

`documentation/agent_doc/wait_premature_expiry_bug.md` has the full
investigation, including a list of the conclusions in the original
report that turned out wrong.

Note for deploying to Münster: that instance runs v1.4.0, which isn't in
this repo. Both defects predate it (`ed56a95f` is tagged in v1.0.0, the
missing `ORDER BY` is older), so this should port — but worth confirming
the two call sites match first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)