### PR TITLE
# fix(export): `seconds_stayed` wrong for expired unit sessions; add missing columns from webview

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/) and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [Unreleased]
+
+### Fixes
+- Run user-detail CSV export: `seconds_stayed` was wrong for every unit session that **expired** rather than ended. `RunHelper::getUserDetailExportPdoStatement()` computed `IF(ended > 0, ended - created, NOW() - created)`, and an expired session has `ended` NULL — so the column reported "time since the participant entered this unit, as of the moment you clicked export" instead of a duration. The number therefore grew on every re-export and contradicted the raw timestamps shown in the admin web view (which selects `created`/`ended`/`expired` unmodified). Affected Survey inactivity expiry and elapsed Pause/Wait units; observed as an ESM run reporting 424 s for a Wait that actually lasted 1 s. Now falls back to `expired` before `NOW()`, so `NOW()` applies only to sessions still genuinely open.
+
 ## [v1.1.1] - 11.06.2026
 
 ### Fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 
 ## [Unreleased]
 
+### Added
+- Run user-detail CSV export now carries `expires`, `queued`, `result` and `result_log`, reaching parity with the admin web view (which renders `expires` — bolded while `queued > 0` — and `result` with `result_log` as its tooltip). Without them a stalled or prematurely expired unit session could not be diagnosed from the export at all: the deadline a Pause/Wait actually computed lives only in `expires`, so the export could show a Wait ending ten minutes early with no way to tell whether the deadline or the expiry was at fault. New columns are appended after the existing ones, so positional parsers of the old 9-column format keep working.
+
 ### Fixes
 - Run user-detail CSV export: `seconds_stayed` was wrong for every unit session that **expired** rather than ended. `RunHelper::getUserDetailExportPdoStatement()` computed `IF(ended > 0, ended - created, NOW() - created)`, and an expired session has `ended` NULL — so the column reported "time since the participant entered this unit, as of the moment you clicked export" instead of a duration. The number therefore grew on every re-export and contradicted the raw timestamps shown in the admin web view (which selects `created`/`ended`/`expired` unmodified). Affected Survey inactivity expiry and elapsed Pause/Wait units; observed as an ESM run reporting 424 s for a Wait that actually lasted 1 s. Now falls back to `expired` before `NOW()`, so `NOW()` applies only to sessions still genuinely open.
 

--- a/application/Helper/RunHelper.php
+++ b/application/Helper/RunHelper.php
@@ -282,6 +282,13 @@ class RunHelper {
      * and disagreed with the raw timestamps rendered by the web view
      * (getUserDetailTable() below, which selects created/ended/expired
      * unmodified). `NOW()` now applies only to sessions still genuinely open.
+     *
+     * The export also carries `expires` / `queued` / `result` / `result_log`
+     * so it reaches parity with the web view (templates/admin/run/user_detail.php
+     * renders `expires`, bolded while `queued > 0`, and `result` with
+     * `result_log` as its tooltip). Without them a stalled or prematurely
+     * expired unit session cannot be diagnosed from the export alone — the
+     * deadline a Pause/Wait actually computed lives only in `expires`.
      */
     public function getUserDetailExportPdoStatement($queryParams) {
         $query = "
@@ -300,7 +307,11 @@ class RunHelper {
 			        END
 			    ) - UNIX_TIMESTAMP(`survey_unit_sessions`.created) AS 'seconds_stayed',
 				`survey_unit_sessions`.ended AS 'left',
-			    `survey_unit_sessions`.expired
+			    `survey_unit_sessions`.expired,
+			    `survey_unit_sessions`.expires,
+			    `survey_unit_sessions`.queued,
+			    `survey_unit_sessions`.result,
+			    `survey_unit_sessions`.result_log
 			FROM `survey_unit_sessions`
 			LEFT JOIN `survey_run_sessions` ON `survey_run_sessions`.id = `survey_unit_sessions`.run_session_id
 			LEFT JOIN `survey_units` ON `survey_unit_sessions`.unit_id = `survey_units`.id

--- a/application/Helper/RunHelper.php
+++ b/application/Helper/RunHelper.php
@@ -271,6 +271,18 @@ class RunHelper {
         );
     }
 
+    /**
+     * PDO statement backing the CSV export of a run's unit-session history.
+     *
+     * `seconds_stayed` must fall back to `expired` before `NOW()`: a unit
+     * session that expired (Survey inactivity expiry, elapsed Pause/Wait)
+     * has `ended` NULL, and the previous `IF(ended > 0, …, NOW() - created)`
+     * therefore reported "time since the unit was entered, as of the moment
+     * of export" instead of a duration. That number grew on every re-export
+     * and disagreed with the raw timestamps rendered by the web view
+     * (getUserDetailTable() below, which selects created/ended/expired
+     * unmodified). `NOW()` now applies only to sessions still genuinely open.
+     */
     public function getUserDetailExportPdoStatement($queryParams) {
         $query = "
             SELECT
@@ -280,7 +292,13 @@ class RunHelper {
 			    `survey_run_units`.description,
 			    `survey_run_sessions`.session,
 			    `survey_unit_sessions`.created AS entered,
-			    IF (`survey_unit_sessions`.ended > 0, UNIX_TIMESTAMP(`survey_unit_sessions`.ended)-UNIX_TIMESTAMP(`survey_unit_sessions`.created), UNIX_TIMESTAMP(NOW())-UNIX_TIMESTAMP(`survey_unit_sessions`.created)) AS 'seconds_stayed',
+			    UNIX_TIMESTAMP(
+			        CASE
+			            WHEN `survey_unit_sessions`.ended   > 0 THEN `survey_unit_sessions`.ended
+			            WHEN `survey_unit_sessions`.expired > 0 THEN `survey_unit_sessions`.expired
+			            ELSE NOW()
+			        END
+			    ) - UNIX_TIMESTAMP(`survey_unit_sessions`.created) AS 'seconds_stayed',
 				`survey_unit_sessions`.ended AS 'left',
 			    `survey_unit_sessions`.expired
 			FROM `survey_unit_sessions`


### PR DESCRIPTION
## Discrepancy see here:
[formr admin.pdf](https://github.com/user-attachments/files/30874782/formr.admin.pdf)
[esm_user_detail.csv](https://github.com/user-attachments/files/30874784/esm_user_detail.csv)

Liebe Grüße!
Tim

## The bug

`RunHelper::getUserDetailExportPdoStatement()` computed the exported
`seconds_stayed` as:

    IF(ended > 0, ended - created, NOW() - created)

A unit session that **expired** rather than **ended** has `ended` NULL, so
every expired row fell into the `NOW()` branch. The column then reported
*"time since the participant entered this unit, as of the moment you clicked
Export"* rather than a duration.

Consequences:

- The number **grows on every re-export** of the same session — it is not a
  property of the data.
- It **contradicts the admin web view**, which selects `created` / `ended` /
  `expired` unmodified via `getUserDetailTable()` and therefore shows the
  truth.
- It affects Survey inactivity expiry and elapsed Pause/Wait units — i.e.
  exactly the units whose timing you would export a user detail CSV to
  investigate.

## Evidence

From an ESM run on a real study (CSV export + printed web view of the same
session, both attached to the issue):

| unit session | unit | entered | expired | real duration | exported `seconds_stayed` |
|---|---|---|---|---|---|
| 1763043 | Wait (50) | 13:49:51 | 13:49:52 | **1 s** | **424** |
| 1762979 | Survey (100) | 13:34:56 | 13:36:08 | 72 s | 1319 |
| 1763003 | Survey (100) | 13:39:32 | 13:40:33 | 61 s | 1043 |
| 1763032 | Survey (100) | 13:47:38 | 13:48:50 | 72 s | 557 |

All nine expired rows in that export resolve to the *same* wall-clock instant:
`entered + seconds_stayed == 13:56:55` for every one of them — the moment the
export ran. That is the fingerprint of the `NOW()` branch. The web view for
the same rows correctly shows "a moment" / "1 minute".

## The fix

Fall back to `expired` before `NOW()`:

```sql
UNIX_TIMESTAMP(
    CASE
        WHEN ended   > 0 THEN ended
        WHEN expired > 0 THEN expired
        ELSE NOW()
    END
) - UNIX_TIMESTAMP(created) AS 'seconds_stayed'
```

`NOW()` now applies only to sessions that are still genuinely open (neither
ended nor expired), where "elapsed so far" is the intended meaning. Rows with
`ended` set are unaffected — no change to existing correct output.

## Also: four columns added to the export

The CSV carried only `created` / `ended` / `expired`, while
`templates/admin/run/user_detail.php` additionally renders `expires` (bolded
while `queued > 0`) and `result` with `result_log` as its tooltip.

That gap made this class of bug undiagnosable from an export alone: a
Pause/Wait's *computed deadline* lives only in `expires`, so an export showing
a 10-minute Wait that ended after 1 second gives no way to tell whether the
deadline was miscomputed or a correct deadline was ignored. Answering that
question here required a PDF print of the web view.

`expires`, `queued`, `result`, `result_log` are appended **after** the existing
nine columns, so positional parsers of the old format keep working.